### PR TITLE
add date-controller with changes and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,69 @@ Or override in step options
 
 Adds `single` or `multiple` to the locals to describe the number of errors for pluralisation of error messages.
 
+--------------------------------
+
+### Date Controller
+
+Accessed as `date` from `hof-controllers`
+
+```js
+var dateController = require('hof-controllers').date;
+```
+
+Extends from `require('hof-controllers').base;`
+
+#### Date validation
+
+- Validates the dates as a single item.
+
+- Date validators default to: `required`, `numeric`, `format` (`DD-MM-YYYY`), and `future`.
+
+- What the validators the date validates against can be overridden with the `validate` property on the date key field.
+
+In this example, the whole date will only validate if it contains non-numeric characters.
+
+```js
+{
+  date: {
+    validate: ['numeric']
+  }
+}
+```
+
+Note: In the preceding example the field is not required and will not error on empty values.
+
+
+#### Extend and override `validateField`
+
+If you want a shared date field to be required, but on a particular page wish it to be optional, `validateField` will accept a third parameter called `isRequired`.
+This will allow the date field to be optional unless the user enters a value, in which case an appropriate message will be shown.
+
+```js
+MyController.prototype.validateField = function validateField(keyToValidate, req) {
+  return DateController.prototype.validateField.call(this, keyToValidate, req, false);
+};
+```
+
+#### Formats date
+
+- Adds a 'pretty' formatted (`D MMMM YYYY`) date to the form values.
+
+------------------------------
+
+### Extending
+
+To extend the functionality of a controller call the parent constructor and use node `util` to inherit the prototype;
+
+```js
+var DateController = function DateController() {
+  Controller.apply(this, arguments);
+};
+
+util.inherits(DateController, Controller);
+```
+------------------------------
+
 ## Test
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
 module.exports = {
-  base: require('./lib/base-controller')
+  base: require('./lib/base-controller'),
+  date: require('./lib/date-controller')
 };

--- a/lib/date-controller.js
+++ b/lib/date-controller.js
@@ -1,0 +1,145 @@
+'use strict';
+
+var util = require('util');
+var Controller = require('./base-controller');
+var ErrorController = require('./error-controller');
+var moment = require('moment');
+var _ = require('underscore');
+var dateFormat = 'DD-MM-YYYY';
+var prettyDate = 'D MMMM YYYY';
+
+var DateController = function DateController() {
+  Controller.apply(this, arguments);
+};
+
+util.inherits(DateController, Controller);
+
+var validators = [
+  {
+    method: function isEmpty(value) {
+      return value === '' || value === undefined;
+    },
+    type: 'required'
+  },
+  {
+    method: function isInvalidChars(value) {
+      var valueParts = value.split('-');
+      return _.some(valueParts, function testForNumeric(part) {
+        return /\D/.test(part);
+      });
+    },
+    type: 'numeric'
+  },
+  {
+    method: function isInvalidDateFormat(value) {
+      return moment(value, dateFormat).isValid(dateFormat) === false;
+    },
+    type: 'format'
+  },
+  {
+    method: function isFutureDate(value) {
+      return moment(value, dateFormat).isAfter(moment()) === true;
+    },
+    type: 'future'
+  }
+];
+
+function getValidatorTypes(key) {
+  return this.options.fields[key].validate || _.pluck(validators, 'type');
+}
+
+function validateDateField(req, key) {
+  var value = req.form.values[this.dateKey];
+  var validatorTypes = getValidatorTypes.call(this, key);
+  var type = _.result(_.find(validators, function findErrorType(validator) {
+    if (validatorTypes.indexOf(validator.type) !== -1) {
+      return validator.method(value);
+    }
+  }), 'type');
+  if (type) {
+    return new ErrorController(this.dateKey, {
+      key: this.dateKey,
+      type: type,
+      redirect: undefined
+    });
+  }
+}
+
+function isDateField(key) {
+  return key.indexOf(this.dateKey) !== -1;
+}
+
+function isDateKey(key) {
+  return key === this.dateKey;
+}
+
+function hasValue(req, key) {
+  return _.identity(req.form.values[key]);
+}
+
+function doValidate(req, key) {
+  if (isDateKey.call(this, key)) {
+    return _.filter(_.keys(req.form.values), isDateField.bind(this)).some(hasValue.bind(null, req));
+  }
+}
+
+DateController.prototype.validateField = function validateField(key, req, isRequired) {
+
+  if (typeof isRequired !== 'boolean') {
+    isRequired = true;
+  }
+
+  if (isRequired === true && isDateKey.call(this, key)) {
+    return validateDateField.call(this, req, key);
+  }
+  if (isRequired === false && doValidate.call(this, req, key)) {
+    return validateDateField.call(this, req, key);
+  }
+
+  if (isRequired === false && isDateKey.call(this, key)) {
+    return undefined;
+  }
+
+  return Controller.prototype.validateField.apply(this, arguments);
+
+};
+
+DateController.prototype.saveValues = function saveValues(req) {
+  this.format.call(this, req);
+  Controller.prototype.saveValues.apply(this, arguments);
+};
+
+DateController.prototype.process = function process(req, res, callback) {
+
+  var dateParts = {};
+  var keys = _.keys(req.form.values);
+
+  _.each(keys, function eachValue(id) {
+    var idParts = id.split('-');
+    var name = idParts[idParts.length - 1];
+    var value = req.form.values[id];
+
+    if (value) {
+      dateParts[name] = value;
+    }
+  });
+
+  if (dateParts.day && dateParts.month && dateParts.year) {
+    req.form.values[this.dateKey] = [dateParts.day, dateParts.month, dateParts.year].join('-');
+  }
+
+  callback();
+};
+
+DateController.prototype.format = function format(req) {
+  if (req.form.values[this.dateKey + '-day']) {
+    var day = req.form.values[this.dateKey + '-day'];
+    var month = req.form.values[this.dateKey + '-month'];
+    var year = req.form.values[this.dateKey + '-year'];
+    month = parseInt(month, 10) - 1;
+    var formattedDate = moment([year, month, day]);
+    req.form.values[this.dateKey + '-formatted'] = formattedDate.format(prettyDate);
+  }
+};
+
+module.exports = DateController;

--- a/lib/error-controller.js
+++ b/lib/error-controller.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var ErrorClass = require('hof').wizard.Error;
+var util = require('util');
+
+var ErrorController = function ErrorController() {
+  ErrorClass.apply(this, arguments);
+};
+
+util.inherits(ErrorController, ErrorClass);
+
+module.exports = ErrorController;

--- a/test/lib/date-controller.js
+++ b/test/lib/date-controller.js
@@ -1,0 +1,282 @@
+'use strict';
+
+var proxyquire = require('proxyquire');
+var moment = require('moment');
+
+var Controller = sinon.stub();
+Controller.prototype = {};
+Controller.prototype.validateField = sinon.stub();
+
+var DateController = proxyquire('../../lib/date-controller', {
+  './base-controller': Controller
+});
+
+var ErrorClass = require('../../lib/error-controller');
+
+describe('lib/date-controller', function () {
+
+  var controller;
+  var args = {template: 'index'};
+
+  beforeEach(function () {
+    controller = new DateController(args);
+    controller.dateKey = 'date';
+    controller.options = {};
+    controller.options.fields = {
+     'date': {}
+    };
+  });
+
+  describe('instantiated', function () {
+    it('calls Controller with the arguments', function () {
+      Controller.should.have.been.called;
+    });
+  });
+
+  describe('validateField(keyToValidate, req)', function () {
+
+    var req = {
+      form: {
+        values: {}
+      }
+    };
+
+    describe('validation', function () {
+
+      describe('required error', function () {
+
+        it('returns an error class when the field is undefined', function () {
+          req.form.values.date = undefined;
+          var undefinedCheck = controller.validateField('date', req);
+
+          undefinedCheck.should.be.an.instanceof(ErrorClass);
+          undefinedCheck.should.have.property('key').and.equal('date');
+          undefinedCheck.should.have.property('type').and.equal('required');
+        });
+
+        it('returns an error class when the field is an empty string', function () {
+          req.form.values.date = '';
+          var emptyStringCheck = controller.validateField('date', req);
+
+          emptyStringCheck.should.be.an.instanceof(ErrorClass);
+          emptyStringCheck.should.have.property('key').and.equal('date');
+          emptyStringCheck.should.have.property('type').and.equal('required');
+        });
+
+      });
+
+      describe('numeric error', function () {
+
+        it('returns an error class when the field is not numeric', function () {
+          req.form.values.date = 'ab-cd-efgh';
+          var numericCheck = controller.validateField('date', req);
+
+          numericCheck.should.be.an.instanceof(ErrorClass);
+          numericCheck.should.have.property('key').and.equal('date');
+          numericCheck.should.have.property('type').and.equal('numeric');
+        });
+
+      });
+
+      describe('format error', function () {
+
+        it('returns an error class when the field is incorrectly formatted', function () {
+          req.form.values.date = '01-13-1982';
+          var formatCheck = controller.validateField('date', req);
+
+          formatCheck.should.be.an.instanceof(ErrorClass);
+          formatCheck.should.have.property('key').and.equal('date');
+          formatCheck.should.have.property('type').and.equal('format');
+        });
+
+      });
+
+      describe('future error', function () {
+
+        it('returns an error class when the field is in the future', function () {
+          req.form.values.date = moment().add(1, 'day').format('DD-MM-YYYY');
+          var formatCheck = controller.validateField('date', req);
+
+          formatCheck.should.be.an.instanceof(ErrorClass);
+          formatCheck.should.have.property('key').and.equal('date');
+          formatCheck.should.have.property('type').and.equal('future');
+        });
+
+      });
+
+      describe('can be overridden', function () {
+
+        it('does not return an error for non-numeric values if numeric is not specficied as a validator', function () {
+          controller.options.fields.date.validate = ['required', 'format', 'future'];
+          req.form.values.date = 'ab-cd-efgh';
+
+          var error = controller.validateField('date', req);
+          error.should.have.property('type').and.not.equal('numeric');
+        });
+
+        it('does not return an error if validate property is empty', function () {
+          controller.options.fields.date.validate = [];
+          req.form.values.date = 'ab-cd-efgh';
+
+          var error = controller.validateField('date', req);
+          should.equal(error, undefined);
+        });
+
+      });
+
+    });
+
+    describe('when the date is not required', function () {
+
+      describe('required error', function () {
+
+        it('does not return an error when the field is undefined', function () {
+          req.form.values.date = undefined;
+
+          should.equal(controller.validateField('date', req, false), undefined);
+        });
+
+        it('does not return an error when the field is an empty string', function () {
+          req.form.values.date = '';
+
+          should.equal(controller.validateField('date', req, false), undefined);
+        });
+
+      });
+
+      describe('numeric error', function () {
+
+        it('returns an error class when the field is not numeric', function () {
+          req.form.values.date = 'ab-cd-efgh';
+          var numericCheck = controller.validateField('date', req, false);
+
+          numericCheck.should.be.an.instanceof(ErrorClass);
+          numericCheck.should.have.property('key').and.equal('date');
+          numericCheck.should.have.property('type').and.equal('numeric');
+        });
+
+      });
+
+      describe('format error', function () {
+
+        it('returns an error class when the field is incorrectly formatted', function () {
+          req.form.values.date = '01-13-1982';
+          var formatCheck = controller.validateField('date', req, false);
+
+          formatCheck.should.be.an.instanceof(ErrorClass);
+          formatCheck.should.have.property('key').and.equal('date');
+          formatCheck.should.have.property('type').and.equal('format');
+        });
+
+      });
+
+      describe('future error', function () {
+
+        it('returns an error class when the field is in the future', function () {
+          req.form.values.date = moment().add(1, 'day').format('DD-MM-YYYY');
+          var formatCheck = controller.validateField('date', req, false);
+
+          formatCheck.should.be.an.instanceof(ErrorClass);
+          formatCheck.should.have.property('key').and.equal('date');
+          formatCheck.should.have.property('type').and.equal('future');
+        });
+
+      });
+
+    });
+
+    describe('valid field', function () {
+
+      it('returns undefined', function () {
+        req.form.values.date = '01-01-2015';
+        should.equal(controller.validateField('date', req), undefined);
+      });
+    });
+
+    describe('when the key is not a date', function () {
+      it('calls the parent class validateField', function () {
+        Controller.prototype.validateField.returns('parent controller');
+
+        controller.validateField('first-name', req).should.equal('parent controller');
+      });
+    });
+  });
+
+  describe('.process()', function () {
+    describe('with all date parts', function () {
+      var callback;
+      var req = {
+        form: {
+          values: {
+            'date-day': '01',
+            'date-month': '01',
+            'date-year': '2015'
+          }
+        }
+      };
+
+      beforeEach(function () {
+        callback = sinon.stub();
+        controller = new DateController(args);
+        controller.dateKey = 'date';
+        controller.process(req, {}, callback);
+      });
+
+      it('creates a date field', function () {
+        req.form.values.date.should.equal('01-01-2015');
+      });
+      it('calls callback', function () {
+        callback.should.have.been.called;
+      });
+
+    });
+    describe('with missing date parts', function () {
+      var callback;
+      var req = {
+        form: {
+          values: {
+            'date-day': '01',
+            'date-month': '',
+            'date-year': '2015'
+          }
+        }
+      };
+
+      beforeEach(function () {
+        callback = sinon.stub();
+        controller = new DateController({template: 'index'});
+        controller.dateKey = 'date';
+        controller.process(req, {}, callback);
+      });
+      it('creates a date field', function () {
+        should.equal(req.form.values.date, undefined);
+      });
+      it('calls callback', function () {
+        callback.should.have.been.called;
+      });
+    });
+  });
+
+  describe('format', function () {
+    var req = {
+      form: {
+        values: {}
+      }
+    };
+    beforeEach(function () {
+      controller = new DateController({template: 'index'});
+      controller.dateKey = 'date';
+    });
+
+    it('formats the date property to GDS style date', function () {
+      req.form.values['date-day'] = '01';
+      req.form.values['date-month'] = '11';
+      req.form.values['date-year'] = '1982';
+
+      controller.format(req);
+
+      req.form.values['date-formatted'].should.equal('1 November 1982');
+    });
+  });
+
+});


### PR DESCRIPTION
- add date controller 
- document date controller
- add error controller without documentation. (it just delegates to hmpo form controller error)
- ensure tests reflect functionality of controller
- amend date controller:
  - default validators
  - defaults can be overriden with field level validate property
  - if overriding, always add `validate` property to "dateKey" field.
