### PR TITLE
Feature/typeahead

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var controllers = require('hof-controllers');
 Accessed as `base` from `hof-controllers`
 
 ```js
-var baseController = require('hof-controllers').base;
+var BaseController = require('hof-controllers').base;
 ```
 
 Extends from [passports-form-wizard](https://github.com/UKHomeOffice/passports-form-wizard) Wizard, Form Controller.
@@ -126,11 +126,10 @@ In this example, if the last condition resolves to true - even if the others als
 
 ### Date Controller
 
-Accessed as `
-` from `hof-controllers`
+Accessed as `date` from `hof-controllers`
 
 ```js
-var dateController = require('hof-controllers').date;
+var DateController = require('hof-controllers').date;
 ```
 
 Extends from `require('hof-controllers').base;`
@@ -175,6 +174,8 @@ MyController.prototype.validateField = function validateField(keyToValidate, req
 
 ### Error Controller
 
+Accessed as `error` from `hof-controllers`
+
 A simple wrapper around `require('hmpo-form-wizard').Error;` to make it easier to extend and customise error behaviour on error.
 
 ### Extending
@@ -193,6 +194,37 @@ var DateController = function DateController() {
 util.inherits(DateController, Controller);
 ```
 ------------------------------
+
+### Typeahead Controller
+
+Accessed as `typeahead` from `hof-controllers`
+
+```js
+var Typeahead = require('hof-controllers').typeahead;
+```
+
+Extends from `require('hof-controllers').base;`
+
+#### Typeahead validation
+
+To use add a key of `typeahead` on the field you want to validate like so:
+
+```
+fields: {
+  country: {
+    typeahead: {
+      list: ['England', 'France', 'Poland']
+    }
+  }
+}
+```
+
+Where `list` is a typeahead list you want to validate against. In practice this can be `required('./assets/countrylist')` in.
+
+The controller will also skip validation if you add a dependency and the criteria isn't met (ala normal field validation).
+
+Calls the parent `validateField` if the field does not have a typeahead field.
+
 
 ## Test
 

--- a/lib/typeahead-controller.js
+++ b/lib/typeahead-controller.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var util = require('util');
+var Controller = require('./base-controller');
+var ErrorClass = require('./error-controller');
+var _ = require('underscore');
+
+var TypeaheadController = function Received() {
+  Controller.apply(this, arguments);
+};
+
+util.inherits(TypeaheadController, Controller);
+
+TypeaheadController.prototype.validateField = function validateField(keyToValidate, req) {
+  var typeahead = this.options.fields[keyToValidate].typeahead;
+  var country = req.form.values[keyToValidate];
+  var dependent = this.options.fields[keyToValidate].dependent;
+  var isDependent = _.isObject(dependent);
+
+  if (_.isObject(typeahead)) {
+    typeahead.list = _.map(typeahead.list, function lowercaseValues(value) {
+      return value.toLowerCase();
+    });
+
+    if (country && typeahead.list.indexOf(country.toLowerCase()) === -1) {
+      if (!isDependent || (isDependent && req.form.values[dependent.field] === dependent.value)) {
+        return new ErrorClass(keyToValidate, {
+          key: keyToValidate,
+          type: 'typeahead',
+          redirect: undefined
+        });
+      }
+    }
+  }
+
+  return Controller.prototype.validateField.apply(this, arguments);
+};
+
+module.exports = TypeaheadController;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-controllers",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A collection of controllers commonly used in HOF",
   "main": "index.js",
   "license": "GPLv2",

--- a/test/lib/typeahead-controller.js
+++ b/test/lib/typeahead-controller.js
@@ -1,0 +1,116 @@
+'use strict';
+
+var Controller = sinon.stub();
+Controller.prototype = {};
+Controller.prototype.validateField = sinon.stub();
+
+var proxyquire = require('proxyquire');
+var TypeaheadController = proxyquire('../../lib/typeahead-controller', {
+  './base-controller': Controller
+});
+var ErrorClass = require('../../lib/error-controller');
+
+describe('lib/typeahead-controller', function () {
+
+  var controller;
+  var args = {
+    fields: {
+      country: {
+        typeahead: {
+          list: ['England', 'France', 'Poland']
+        }
+      }
+    }
+  };
+
+  beforeEach(function () {
+    controller = new TypeaheadController(args);
+    controller.options = args;
+  });
+
+  describe('instantiated', function () {
+    it('calls Controller with the arguments', function () {
+      Controller.should.have.been.called;
+    });
+  });
+
+  describe('validateField(keyToValidate, req)', function () {
+
+    var req = {
+      form: {
+        values: {}
+      }
+    };
+
+    describe('validating the list', function () {
+      it('returns Error if the item is not on the list', function () {
+        req.form.values.country = 'Polska';
+        var countryListCheck = controller.validateField('country', req);
+
+        countryListCheck.should.be.an.instanceof(ErrorClass);
+        countryListCheck.should.have.property('key').and.equal('country');
+        countryListCheck.should.have.property('type').and.equal('typeahead');
+      });
+
+      it('calls the base controller if a country is on the list', function () {
+        req.form.values.country = 'Poland';
+        controller.validateField('country', req);
+
+        Controller.should.have.been.called;
+      });
+
+      describe('dependent fields', function () {
+        it('calls the parent controller if the dependent field is not present', function () {
+          controller.options = {
+            dependent: {
+              field: 'other-field',
+              value: 'yes'
+            },
+            fields: {
+              country: {
+                typeahead: {
+                  list: ['England', 'France', 'Poland']
+                }
+              }
+            }
+          };
+
+          req.form.values = {
+            country: 'Poland'
+          };
+
+          controller.validateField('country', req);
+
+          Controller.should.have.been.called;
+        });
+
+        it('errors if dependent field is present and the item is not on the list', function () {
+          controller.options = {
+            dependent: {
+              field: 'other-field',
+              value: 'yes'
+            },
+            fields: {
+              country: {
+                typeahead: {
+                  list: ['England', 'France', 'Poland']
+                }
+              }
+            }
+          };
+
+          req.form.values = {
+            country: 'Polska',
+            'other-field': 'yes'
+          };
+
+          var countryListCheck = controller.validateField('country', req);
+
+          countryListCheck.should.be.an.instanceof(ErrorClass);
+        });
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
### Typeahead Controller

Accessed as `typeahead` from `hof-controllers`

``` js
var Typeahead = require('hof-controllers').typeahead;
```

Extends from `require('hof-controllers').base;`
#### Typeahead validation

To use add a key of `typeahead` on the field you want to validate like so:

```
fields: {
  country: {
    typeahead: {
      list: ['England', 'France', 'Poland']
    }
  }
}
```

Where `list` is a typeahead list you want to validate against. In practice this can be `required('./assets/countrylist')` in.

The controller will also skip validation if you add a dependency and the criteria isn't met (ala normal field validation).

Calls the parent `validateField` if the field does not have a typeahead field.
