### PR TITLE
If a fork condition is met we should go back to the confirm page (unless another fork condition is met)

### DIFF
--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -26,27 +26,37 @@ function getErrorLength() {
 BaseController.prototype.getNextStep = function getNextStep(req, res) {
   var next = Controller.prototype.getNextStep.apply(this, arguments);
   var forks = (this.options || {}).forks || [];
+  var forked = false;
 
   _.each(forks, function eachFork(fork) {
     if (_.isFunction(fork.condition)) {
       if (fork.condition(req, res)) {
-        next = req.baseUrl + fork.target;
+        if (!_.includes(req.sessionModel.get('steps'), fork.target)) {
+          next = req.baseUrl + fork.target;
+          forked = true;
+        }
       }
     }
     if (_.isPlainObject(fork.condition)) {
       if (fork.condition.value === req.form.values[fork.condition.field]) {
-        next = req.baseUrl + fork.target;
+        if (!_.includes(req.sessionModel.get('steps'), fork.target)) {
+          next = req.baseUrl + fork.target;
+          forked = true;
+        }
       }
     }
   });
 
-  if (req.params.action === 'edit' && !this.options.continueOnEdit) {
+  if (forked) {
+    return next;
+  } else if (req.params.action === 'edit' && !this.options.continueOnEdit) {
     next = req.baseUrl === '/' ? this.confirmStep : req.baseUrl + this.confirmStep;
   } else if (req.params.action === 'edit') {
     next += '/edit';
   }
 
   return next;
+
 };
 
 BaseController.prototype.getErrorStep = function getErrorStep(err, req) {

--- a/test/lib/base-controller.js
+++ b/test/lib/base-controller.js
@@ -194,8 +194,14 @@ describe('lib/base-controller', function () {
       });
 
       describe('with a fork', function () {
+        var getStub;
 
         beforeEach(function () {
+          getStub = sinon.stub();
+          req.sessionModel = {
+            reset: sinon.stub(),
+            get: getStub
+          };
           req.form = {values: {}};
           hmpoFormWizard.Controller.prototype.getNextStep.returns('/next-page');
         });
@@ -258,6 +264,7 @@ describe('lib/base-controller', function () {
 
         describe('when the action is "edit"', function () {
           it('appends "edit" to the path', function () {
+            getStub.returns(['/target-page']);
             req.form.values['example-radio'] = 'superman';
             controller.options.forks = [{
               target: '/target-page',


### PR DESCRIPTION
Say we have two conditions for a step:

```
'/letter-received': {
    fields: [
      'received',
      'delivery-date',
      'delivery-date-day',
      'delivery-date-month',
      'delivery-date-year',
      'no-letter'
    ],
    next: '/same-address',
    forks: [{
      target: '/letter-not-received',
      condition: {
        field: 'received',
        value: 'no'
      }
    }, {
      target: '/letter-lost',
      condition: {
        field: 'no-letter',
        value: 'true'
      }
    }]
  }
```

Currently if get to the edit (confirm page) then go back to that step to edit it (and hit a fork) it won't go down the fork it will just return to the edit page.

This is a bug as it should potentially end journeys for people or ask for extra information (on other steps).

Here is it broken:

![](https://s3.amazonaws.com/f.cl.ly/items/0F1R2m1b0x3L3B0Q3r0j/Screen%20Recording%202016-04-05%20at%2005.21%20pm.gif?v=3ab7b1ca)

And here is it with the base controller change in this PR:

![](https://s3.amazonaws.com/f.cl.ly/items/0l3p2t2b430k3B2q3Y2V/Screen%20Recording%202016-04-05%20at%2005.20%20pm.gif?v=961974a0)
