### PR TITLE
Allows user to decide their own dateFormat and prettyDate format

### DIFF
--- a/lib/date-controller.js
+++ b/lib/date-controller.js
@@ -10,7 +10,9 @@ var prettyDate = 'D MMMM YYYY';
 
 var DateController = function DateController(options) {
   Controller.apply(this, arguments);
-  this.options = options || {};
+  if (_.isUndefined(this.options)) {
+    this.options = options || {};
+  }
 };
 
 util.inherits(DateController, Controller);

--- a/lib/date-controller.js
+++ b/lib/date-controller.js
@@ -8,8 +8,9 @@ var _ = require('lodash');
 var dateFormat = 'DD-MM-YYYY';
 var prettyDate = 'D MMMM YYYY';
 
-var DateController = function DateController() {
+var DateController = function DateController(options) {
   Controller.apply(this, arguments);
+  this.options = options || {};
 };
 
 util.inherits(DateController, Controller);
@@ -110,6 +111,7 @@ DateController.prototype.saveValues = function saveValues(req) {
 };
 
 DateController.prototype.process = function process(req, res, callback) {
+  dateFormat = (this.options.dateFormat) ? this.options.dateFormat : dateFormat;
 
   var dateParts = {};
   var keys = _.keys(req.form.values);
@@ -125,13 +127,16 @@ DateController.prototype.process = function process(req, res, callback) {
   });
 
   if (dateParts.day && dateParts.month && dateParts.year) {
-    req.form.values[this.dateKey] = [dateParts.day, dateParts.month, dateParts.year].join('-');
+    req.form.values[this.dateKey] = moment([dateParts.day, dateParts.month, dateParts.year].join(' '), 'DD MM YYYY')
+                                    .format(dateFormat);
   }
 
   callback();
 };
 
 DateController.prototype.format = function format(req) {
+  prettyDate = (this.options.prettyDate) ? this.options.prettyDate : prettyDate;
+
   if (req.form.values[this.dateKey + '-day']) {
     var day = req.form.values[this.dateKey + '-day'];
     var month = req.form.values[this.dateKey + '-month'];

--- a/test/lib/date-controller.js
+++ b/test/lib/date-controller.js
@@ -258,24 +258,57 @@ describe('lib/date-controller', function () {
   });
 
   describe('format', function () {
-    var req = {
-      form: {
-        values: {}
-      }
-    };
-    beforeEach(function () {
-      controller = new DateController({template: 'index'});
-      controller.dateKey = 'date';
-    });
+    var callback;
+      var req = {
+        form: {
+          values: {}
+        }
+      };
+      
+     beforeEach(function () {
+        callback = sinon.stub();
+        controller = new DateController({template: 'index'});
+        controller.dateKey = 'date';
+        controller.options = {};
+        controller.process(req, {}, callback);
+      });
 
-    it('formats the date property to GDS style date', function () {
+    it('formats the date property to GDS style date if no prettyDate option passed in', function () {
       req.form.values['date-day'] = '01';
       req.form.values['date-month'] = '11';
       req.form.values['date-year'] = '1982';
 
       controller.format(req);
-
       req.form.values['date-formatted'].should.equal('1 November 1982');
+    });
+
+    it('takes a custom date style date if prettyDate option passed in', function () {
+      req.form.values['date-day'] = '01';
+      req.form.values['date-month'] = '11';
+      req.form.values['date-year'] = '1982';
+      controller.options.prettyDate = 'D/MMMM/YYYY';
+
+      controller.format(req);
+      req.form.values['date-formatted'].should.equal('1/November/1982');
+    });
+
+    it('sets dataFormat to DD-MM-YYYY if no dateFormat option passed in', function() {
+      req.form.values['date-day'] = '01';
+      req.form.values['date-month'] = '11';
+      req.form.values['date-year'] = '1982';
+      req.form.values.date.should.equal('01-11-1982');
+    });
+
+    it('takes a custom date format if the dateFormat option passed in', function () {
+      var res = {};
+      var callback = sinon.stub();
+      req.form.values['date-day'] = '01';
+      req.form.values['date-month'] = '11';
+      req.form.values['date-year'] = '1982';
+      controller.options.dateFormat = 'YYYY MM DD';
+
+      controller.process(req, {}, callback);
+      req.form.values.date.should.equal('1982 11 01');
     });
   });
 

--- a/test/lib/date-controller.js
+++ b/test/lib/date-controller.js
@@ -259,19 +259,19 @@ describe('lib/date-controller', function () {
 
   describe('format', function () {
     var callback;
-      var req = {
-        form: {
-          values: {}
-        }
-      };
-      
-     beforeEach(function () {
-        callback = sinon.stub();
-        controller = new DateController({template: 'index'});
-        controller.dateKey = 'date';
-        controller.options = {};
-        controller.process(req, {}, callback);
-      });
+    var req = {
+      form: {
+        values: {}
+      }
+    };
+
+   beforeEach(function () {
+      callback = sinon.stub();
+      controller = new DateController({template: 'index'});
+      controller.dateKey = 'date';
+      controller.options = {};
+      controller.process(req, {}, callback);
+    });
 
     it('formats the date property to GDS style date if no prettyDate option passed in', function () {
       req.form.values['date-day'] = '01';
@@ -300,8 +300,7 @@ describe('lib/date-controller', function () {
     });
 
     it('takes a custom date format if the dateFormat option passed in', function () {
-      var res = {};
-      var callback = sinon.stub();
+      callback = sinon.stub();
       req.form.values['date-day'] = '01';
       req.form.values['date-month'] = '11';
       req.form.values['date-year'] = '1982';


### PR DESCRIPTION
Adding
``{...,
dateFormat: 'YYYY-MM-DD',
prettyDate: 'DD/MMMM/YYYY,
...}`

to the step.js options lets you change the date formats`
