### PR TITLE
Expose data for creation of config page programatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,53 @@ util.inherits(DateController, Controller);
 ```
 ------------------------------
 
+### Confirm Controller
+
+Extends the base controller's locals method to provide data in a format suitable for generating a summary table.
+
+Accessed as `confirm` from `hof-controllers`.
+
+```js
+var confirmController = require('hof-controllers').confirm;
+```
+
+Extends from `require('hof-controllers').base`
+
+#### Usage
+
+In step options
+
+```js
+'/confirm': {
+  controller: require('hof-controllers').confirm,
+  config: {
+    tableSections: [{
+      name: 'section-one',
+      fields: [
+        'field-one',
+        'field-two',
+        'field-three'
+      ]
+    }],
+    modifiers: { // transform {{value}}, values hash provided
+      'field-two': function(values) {
+        return values['field-two'].toUpperCase();
+      }
+    }
+  }
+}
+```
+
+In config page template
+
+```html
+{{#tableSections}}
+  {{> partials-summary-table}} <!-- {{name}}, {{value}} and {{step}} are available in this scope -->
+{{/tableSections}}
+```
+
+------------------------------
+
 ## Test
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -3,5 +3,6 @@
 module.exports = {
   base: require('./lib/base-controller'),
   date: require('./lib/date-controller'),
+  confirm: require('./lib/confirm-controller'),
   error: require('./lib/error-controller')
 };

--- a/lib/confirm-controller.js
+++ b/lib/confirm-controller.js
@@ -1,0 +1,69 @@
+'use strict';
+
+var util = require('util');
+var Controller = require('./base-controller');
+var _ = require('lodash');
+
+var ConfirmController = function ConfirmController(options) {
+  Controller.apply(this, arguments);
+  this.options = options || {};
+};
+
+util.inherits(ConfirmController, Controller);
+
+/*
+ * Utility function which returns the
+ * name of the step a field is present on
+ */
+function getStepFromFieldName(fieldName, steps) {
+  return _.findKey(steps, function findKey(step) {
+    if (!step.fields) {
+      return false;
+    }
+    return step.fields.indexOf(fieldName) > -1;
+  });
+}
+
+/*
+ * Utility function to create an array
+ * of field objects made up of field name,
+ * value and step
+ */
+function getFieldObjectsFromNames(fields, values, modifiers, steps) {
+  return fields.filter(function filter(item) {
+    return (values[item] !== undefined && values[item] !== '') || modifiers[item] !== undefined;
+  }).map(function map(item) {
+    var value = values[item];
+    var step = getStepFromFieldName(item, steps);
+    if (modifiers[item]) {
+      value = modifiers[item](values);
+    }
+    return {
+      name: item,
+      value: value,
+      step: step
+    };
+  });
+}
+
+ConfirmController.prototype.locals = function controllerLocals(req, res) {
+  var locals = Controller.prototype.locals.apply(this, arguments);
+  var config = _.cloneDeep(this.options).config || {};
+  var tableSections = config.tableSections || [];
+  var steps = this.options.steps;
+
+  tableSections.forEach(function forEach(section, index, array) {
+    array[index].fields = getFieldObjectsFromNames(
+      section.fields,
+      res.locals.values,
+      config.modifiers || {},
+      steps
+    );
+  });
+
+  return _.extend({}, locals, {
+    tableSections: tableSections
+  });
+};
+
+module.exports = ConfirmController;

--- a/test/lib/confirm-controller.js
+++ b/test/lib/confirm-controller.js
@@ -1,0 +1,109 @@
+'use strict';
+
+var proxyquire = require('proxyquire');
+
+var Controller = sinon.stub();
+Controller.prototype = {};
+
+var ConfirmController = proxyquire('../../lib/confirm-controller', {
+  './base-controller': Controller
+});
+
+describe('lib/confirm-controller', function () {
+  var req = {
+    params: {}
+  };
+  var res = {};
+  var controller;
+
+  beforeEach(function () {
+    controller = new ConfirmController({
+      template: 'foo'
+    });
+    controller.getErrors = sinon.stub().returns({foo: true});
+    res.locals = {};
+    res.locals.values = {
+      'field-one': 1,
+      'field-two': 2,
+      'field-three': 3,
+      'field-four': 4
+    };
+
+    controller.options = {
+      steps: {
+        '/one': {
+          fields: ['field-one', 'field-two']
+        },
+        '/two': {
+          fields: ['field-three', 'field-four']
+        }
+      },
+      config: {
+        tableSections: [{
+          name: 'test',
+          fields: [
+            'field-one',
+            'field-two',
+            'field-three',
+            'field-four'
+          ]
+        }]
+      }
+    };
+  });
+
+  describe('tableSections', function () {
+    var locals;
+
+    beforeEach(function() {
+      locals = controller.locals(req, res);
+    });
+
+    it('should have exposed a tableSections array', function () {
+      locals.should.have.property('tableSections').and.be.an.instanceOf(Array);
+    });
+
+    it('should have 1 section', function () {
+      locals.tableSections.length.should.be.equal(1);
+    });
+
+    it('should have a fields array', function () {
+      locals.tableSections[0].should.have.property('fields').and.be.an.instanceOf(Array);
+    });
+
+    describe('fields', function () {
+      var fields;
+
+      beforeEach(function () {
+        fields = locals.tableSections[0].fields;
+      });
+
+      it('should have 4 items', function () {
+        fields.length.should.be.equal(4);
+      });
+
+      it('should contain objects', function () {
+        fields[0].should.be.an.instanceOf(Object);
+        fields[1].should.be.an.instanceOf(Object);
+        fields[2].should.be.an.instanceOf(Object);
+        fields[3].should.be.an.instanceOf(Object);
+      });
+
+      it('should have set value: 1 on the field object', function () {
+        fields[0].should.have.property('value').and.equal(1);
+      });
+
+      it('should have set step: /one on the field object', function () {
+        fields[0].should.have.property('step').and.equal('/one');
+      });
+
+      it('should have set value 3 on the 3rd field object', function () {
+        fields[2].should.have.property('value').and.equal(3);
+      });
+
+      it('should have set step: /two on the 3rd field object', function () {
+        fields[3].should.have.property('step').and.equal('/two');
+      });
+    });
+  });
+});


### PR DESCRIPTION
- extend BaseController.prototype.locals return object with modelData from current step config
- if modelData.tableSections is present, each section is processed and a fields array of objects is created exposing value, name and step
- Custom value displaying is achieved by including a modifiers hash in the modelData object
