### PR TITLE
Check next stage is not /confirm stage before appending …

### DIFF
--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -27,6 +27,7 @@ BaseController.prototype.getNextStep = function getNextStep(req, res) {
   var next = Controller.prototype.getNextStep.apply(this, arguments);
   var forked = false;
   var forks = this.options.forks || [];
+  var confirmStep = req.baseUrl === '/' ? this.confirmStep : req.baseUrl + this.confirmStep;
 
   _.each(forks, function eachFork(fork) {
     if (_.isFunction(fork.condition)) {
@@ -47,16 +48,16 @@ BaseController.prototype.getNextStep = function getNextStep(req, res) {
     }
   });
 
-  if (forked) {
+  if (forked || next === confirmStep) {
     return next;
-  } else if (req.params.action === 'edit' && !this.options.continueOnEdit) {
-    next = req.baseUrl === '/' ? this.confirmStep : req.baseUrl + this.confirmStep;
   } else if (req.params.action === 'edit') {
-    next += '/edit';
+    if (!this.options.continueOnEdit) {
+      next = confirmStep;
+    } else {
+      next += '/edit';
+    }
   }
-
   return next;
-
 };
 
 BaseController.prototype.getErrorStep = function getErrorStep(err, req) {

--- a/test/lib/base-controller.js
+++ b/test/lib/base-controller.js
@@ -226,6 +226,22 @@ describe('lib/base-controller', function () {
         });
       });
 
+      describe('when the action is "edit" and continueOnEdit is truthy', function () {
+        it('appends "/edit" to the path if next page is not /confirm', function () {
+          hmpoFormWizard.Controller.prototype.getNextStep = sinon.stub().returns('/step');
+          controller.options.continueOnEdit = true;
+          req.params.action = 'edit';
+          controller.getNextStep(req).should.contain('/edit');
+        });
+
+        it('doesn\'t append "/edit" to the path if next page is /confirm', function () {
+          hmpoFormWizard.Controller.prototype.getNextStep = sinon.stub().returns('/confirm');
+          controller.options.continueOnEdit = true;
+          req.params.action = 'edit';
+          controller.getNextStep(req).should.not.contain('/edit');
+        });
+      });
+
       describe('with a fork', function () {
         var getStub;
 


### PR DESCRIPTION
…/edit to URL
- if `req.params.action === 'edit'` and next stage is /confirm, `/edit` is appended to the URL breaking all relative paths.
- Added check in conditional - if next stage is confirm, don't append `/edit`
