### PR TITLE
Closes #29 - Allow passing of custom params to step template

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ Or override in step options
 
 Adds `single` or `multiple` to the locals to describe the number of errors for pluralisation of error messages.
 
+#### Exposes meta to templates
+
+Add a locals object to step config to expose configurable key/value pairs in the template. Useful for generating template partials programmatically. These will override any locals provided further up the tree.
+
+Steps config
+```js
+'/step-name': {
+  locals: {
+    pageTitle: 'Page Title'
+    foo: 'bar'
+  }
+}
+```
+
+Template
+```html
+<h1>{{pageTitle}}</h1>
+<div class="{{foo}}"></div>
+```
+
 #### Handles journey forking
 
 Each step definition accepts a `next` property, the value of which is the next route in the journey. By default, when the form is successfully submitted, the next steps will load. However, there are times when it is necessary to fork from the current journey based on a users response to certain questions in a form. For such circumstances there exists the `forks` property.
@@ -199,4 +219,3 @@ util.inherits(DateController, Controller);
 ```bash
 $ npm test
 ```
-

--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -4,8 +4,8 @@ var Controller = require('hmpo-form-wizard').Controller;
 var util = require('util');
 var _ = require('lodash');
 
-var BaseController = function BaseController() {
-  this.confirmStep = '/confirm';
+var BaseController = function BaseController(options) {
+  this.confirmStep = options.confirmStep || '/confirm';
   Controller.apply(this, arguments);
 };
 
@@ -25,8 +25,8 @@ function getErrorLength() {
 
 BaseController.prototype.getNextStep = function getNextStep(req, res) {
   var next = Controller.prototype.getNextStep.apply(this, arguments);
-  var forks = (this.options || {}).forks || [];
   var forked = false;
+  var forks = this.options.forks || [];
 
   _.each(forks, function eachFork(fork) {
     if (_.isFunction(fork.condition)) {
@@ -69,11 +69,13 @@ BaseController.prototype.getErrorStep = function getErrorStep(err, req) {
 
 BaseController.prototype.locals = function controllerLocals(req, res) {
   var locals = Controller.prototype.locals.apply(this, arguments);
+  var stepLocals = this.options.locals || {};
+
   return _.extend({}, locals, {
     baseUrl: req.baseUrl,
     nextPage: this.getNextStep(req, res),
     errorLength: getErrorLength.apply(this, arguments)
-  });
+  }, stepLocals);
 };
 
 BaseController.prototype.getValues = function getValues(req, res, callback) {

--- a/test/lib/base-controller.js
+++ b/test/lib/base-controller.js
@@ -15,7 +15,9 @@ describe('lib/base-controller', function () {
   describe('constructor', function () {
 
     beforeEach(function () {
-      hmpoFormWizard.Controller = sinon.stub();
+      hmpoFormWizard.Controller = sinon.stub(hmpoFormWizard, 'Controller', function() {
+        this.options = {};
+      });
       hmpoFormWizard.Controller.prototype.locals = sinon.stub().returns({foo: 'bar'});
       Controller = proxyquire('../../lib/base-controller', {
         'hmpo-form-wizard': hmpoFormWizard
@@ -70,6 +72,37 @@ describe('lib/base-controller', function () {
           .and.deep.equal({
             multiple: true
           });
+      });
+
+      describe('with locals', function () {
+        beforeEach(function () {
+          controller.getErrors = sinon.stub().returns({foo: true});
+          res.locals = {};
+          res.locals.values = {
+            'field-one': 1,
+            'field-two': 2,
+            'field-three': 3,
+            'field-four': 4
+          };
+
+          controller.options = {
+            steps: {
+              '/one': {
+                fields: ['field-one', 'field-two']
+              },
+              '/two': {
+                fields: ['field-three', 'field-four']
+              }
+            },
+            locals: {
+              test: 'bar',
+            }
+          };
+        });
+
+        it('should expose test in locals', function () {
+          controller.locals(req, res).should.have.property('test').and.equal('bar');
+        });
       });
     });
 


### PR DESCRIPTION
- Added to locals method to check step config for meta object, if present expose add all keys to locals for use in template
- Added docs including usage in README
- This is to generate templates programmatically and avoid repeating code
