### PR TITLE
Bugfix & Refactor: Help ensure user cannot skip steps

### DIFF
--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -25,38 +25,36 @@ function getErrorLength() {
 
 BaseController.prototype.getNextStep = function getNextStep(req, res) {
   var next = Controller.prototype.getNextStep.apply(this, arguments);
-  var forked = false;
   var forks = this.options.forks || [];
   var confirmStep = req.baseUrl === '/' ? this.confirmStep : req.baseUrl + this.confirmStep;
 
-  _.each(forks, function eachFork(fork) {
-    if (_.isFunction(fork.condition)) {
-      if (fork.condition(req, res)) {
-        if (!_.includes(req.sessionModel.get('steps'), fork.target)) {
-          next = req.baseUrl + fork.target;
-          forked = true;
-        }
-      }
-    }
-    if (_.isPlainObject(fork.condition)) {
-      if (fork.condition.value === req.form.values[fork.condition.field]) {
-        if (!_.includes(req.sessionModel.get('steps'), fork.target)) {
-          next = req.baseUrl + fork.target;
-          forked = true;
-        }
-      }
-    }
-  });
+  var completed = function completed(step) {
+    // Has the user already completed the step?
+    return _.includes(req.sessionModel.get('steps'), step);
+  };
 
-  if (forked || next === confirmStep) {
-    return next;
-  } else if (req.params.action === 'edit') {
-    if (!this.options.continueOnEdit) {
-      next = confirmStep;
-    } else {
-      next += '/edit';
-    }
+  // If a form condition is met, its target supercedes the next property
+  next = _.reduce(forks, function forkFold(result, value) {
+    var evalCondition = function evalCondition(condition) {
+      return _.isFunction(condition) ?
+        condition(req, res) :
+        condition.value === req.form.values[condition.field];
+    };
+
+    return evalCondition(value.condition) ?
+      req.baseUrl + value.target :
+      result;
+  }, next);
+
+  if ((req.params.action === 'edit') && completed(next)) {
+    // The user is editing the form and has already completed the next
+    // step, so let's check whether we should fast-forward them to the
+    // confirm page
+    next = (!this.options.continueOnEdit || next === confirmStep) ?
+      confirmStep :
+      next + '/edit';
   }
+
   return next;
 };
 


### PR DESCRIPTION
- Adds tests to demonstrate a bug in editing forks. Namely, that when a
  user completes a forked form to the point of reaching the confirm page,
  having followed a fork, they can edit the form to follow the standard
  route and avoid completing the steps in the standard path.
- Bugfix and re-factor of .getNextStep

Addresses #33.
