### PR TITLE
Remove steps from sessionModel if all fields have been invalidated

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ Extends from [passports-form-wizard](https://github.com/UKHomeOffice/passports-f
   /* step options */
 }
 ```
+
+#### Added functionality for invalidating steps
+
+Removing fields from the session when the value of another field is changed. In the following example, when the value of `a_field` is changed, `field_1` and `field_2` - and their values - will be removed from the session model. If all the fields in a step are removed in this way, the entire step is removed from the session model too.
+
+This is useful when a user takes a fork in a journey, only to return to the fork and take the other route.
+
+```js
+a_field: {
+    invalidates: ['field_1', 'field_2']
+}
+```
+
 #### Handles edit actions.
 
 In the wizard options

--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -23,6 +23,57 @@ function getErrorLength() {
   }
 }
 
+/*
+ * Utility function which accepts an array of invalidating fields
+ * and the steps config object, returns a filtered steps object
+ * containing fields which have been invalidated.
+ */
+function getStepsToCheck(fields, steps) {
+  return _.pick(steps, function pickSteps(step) {
+    if (!step.fields) {
+      return false;
+    }
+    return _.intersection(step.fields, fields).length;
+  });
+}
+
+/*
+ * Utility function which accepts an array of invalidating fields,
+ * the steps config object and the sessionModel. It returns an array
+ * of step names for which all fields have been invalidated.
+ */
+function getInvalidatedSteps(fields, steps, sessionModel) {
+  var stepsToCheck = getStepsToCheck(fields, steps);
+
+  return _.chain(stepsToCheck).pick(function pickSteps(step) {
+    return _.every(step.fields, function everyField(item) {
+      return sessionModel.get(item) === undefined;
+    });
+  }).keys().value();
+}
+
+BaseController.prototype.saveValues = function saveValues(req) {
+  this.invalidateSteps(req);
+  Controller.prototype.saveValues.apply(this, arguments);
+};
+
+/*
+ * Remove any steps from the sessionModel
+ * that have had all of their fields invalidated
+ */
+BaseController.prototype.invalidateSteps = function invalidateSteps(req) {
+  var steps = this.options.steps;
+  var invalidatingFields = _.pick(this.options.fields, function pickFields(field) {
+    return field && field.invalidates && field.invalidates.length;
+  });
+  _.each(invalidatingFields, function eachInvalidatingField(field, key) {
+    req.sessionModel.on('change:' + key, function onChange() {
+      var invalidatedSteps = getInvalidatedSteps(field.invalidates, steps, req.sessionModel);
+      req.sessionModel.set('steps', _.difference(req.sessionModel.get('steps'), invalidatedSteps));
+    });
+  });
+};
+
 BaseController.prototype.getNextStep = function getNextStep(req, res) {
   var next = Controller.prototype.getNextStep.apply(this, arguments);
   var forks = this.options.forks || [];

--- a/test/lib/base-controller.js
+++ b/test/lib/base-controller.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var proxyquire = require('proxyquire');
+var EventEmitter = require('events');
+var util = require('util');
 
 describe('lib/base-controller', function () {
 
@@ -474,6 +476,71 @@ describe('lib/base-controller', function () {
           req.params.action = 'edit';
           controller.getErrorStep(err, req).should.contain('/edit');
         });
+      });
+
+    });
+
+    describe('.invalidateSteps()', function () {
+      var req = {};
+
+      beforeEach(function () {
+        hmpoFormWizard.Controller.prototype.saveValues = sinon.stub();
+
+        var SessionModel = function() {
+          EventEmitter.call(this);
+        };
+
+        util.inherits(SessionModel, EventEmitter);
+
+        SessionModel.prototype.set = function set(key, value) {
+          this[key] = value;
+        };
+
+        SessionModel.prototype.get = function get(key) {
+          return this[key];
+        };
+
+        req.sessionModel = new SessionModel();
+        req.sessionModel.set('steps', ['/step1', '/step2', '/step3']);
+        req.sessionModel.set('testField', 'A Value');
+        controller = new Controller({template: 'foo'});
+        controller.options.steps = {
+          '/step1': {
+            fields: [
+              'fieldOne',
+              'fieldTwo'
+            ]
+          },
+          '/step2': {
+            fields: [
+              'testField'
+            ]
+          }
+        };
+      });
+
+      it('should invalidate stepOne as all fields are invalidated', function () {
+        controller.options.fields = {
+          testField: {
+            invalidates: ['fieldOne', 'fieldTwo']
+          }
+        };
+        controller.invalidateSteps(req);
+        req.sessionModel.emit('change:testField');
+        req.sessionModel.get('steps').should.not.contain('/step1');
+      });
+
+      it('should not invalidate stepOne if it contains a field that isn\'t invalidated', function () {
+        req.sessionModel.set('fieldOne', true);
+        req.sessionModel.set('fieldTwo', true);
+        controller.options.fields = {
+          testField: {
+            invalidates: ['fieldTwo']
+          }
+        };
+        controller.invalidateSteps(req);
+        req.sessionModel.emit('change:testField');
+        req.sessionModel.get('steps').should.contain('/step1');
       });
 
     });


### PR DESCRIPTION
- Hook into `Controller.prototype.saveValues` which is called before fields are amended in the sessionModel
- When an invalidating field is changed, check which steps have had all fields invalidated
- remove these steps from the sessionModel
