### PR TITLE
Invalidate unreachable steps when a fork condition is reached

### DIFF
--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -23,8 +23,31 @@ function getErrorLength() {
   }
 }
 
+// Accepts a step and the steps config object
+// returns an array of all step names that
+// can be reached from the given step
+function getAllPossibleSteps(stepName, steps) {
+  var allSteps = [stepName];
+  var step = steps[stepName];
+  while (step && step.next) {
+    allSteps.push(step.next);
+    var forks = step.forks || [];
+    /*eslint-disable no-loop-func*/
+    allSteps = allSteps.concat(forks.reduce(function getForks(arr, fork) {
+      /*eslint-enable no-loop-func*/
+      return getAllPossibleSteps(fork.target, steps);
+    }, []));
+    step = steps[step.next];
+  }
+  return _.uniq(allSteps);
+}
+
 BaseController.prototype.getNextStep = function getNextStep(req, res) {
   var next = Controller.prototype.getNextStep.apply(this, arguments);
+  // We only want to execute forking logic on POST requests
+  if (req.method !== 'POST') {
+    return next;
+  }
   var forks = this.options.forks || [];
   var confirmStep = req.baseUrl === '/' ? this.confirmStep : req.baseUrl + this.confirmStep;
 
@@ -41,10 +64,20 @@ BaseController.prototype.getNextStep = function getNextStep(req, res) {
         condition.value === req.form.values[condition.field];
     };
 
-    return evalCondition(value.condition) ?
+    var conditionSatisfied = evalCondition(value.condition);
+
+    // if fork condition satisfied, invalidate next path
+    // if not, invalidate fork target path
+    if (conditionSatisfied) {
+      this.invalidatePath(this.options.next, value.target, req.sessionModel);
+    } else {
+      this.invalidatePath(value.target, this.options.next, req.sessionModel);
+    }
+
+    return conditionSatisfied ?
       req.baseUrl + value.target :
       result;
-  }, next);
+  }.bind(this), next);
 
   if ((req.params.action === 'edit') && completed(next)) {
     // The user is editing the form and has already completed the next
@@ -56,6 +89,28 @@ BaseController.prototype.getNextStep = function getNextStep(req, res) {
   }
 
   return next;
+};
+
+// Accepts start point of journey to invalidate, start point of journey
+// not to invalidate and the sessionModel. Calls invalidateSteps on all
+// steps that are reachable via invalidateStart but not validateStart
+BaseController.prototype.invalidatePath = function invalidatePath(invalidateStart, validateStart, sessionModel) {
+  var invalidateSteps = getAllPossibleSteps(invalidateStart, this.options.steps);
+  var validateSteps = getAllPossibleSteps(validateStart, this.options.steps);
+
+  _.difference(invalidateSteps, validateSteps).forEach(function eachStep(step) {
+    this.invalidateStep(step, sessionModel);
+  }.bind(this));
+};
+
+// Accepts a string stepName and the sessionModel.
+// Unsets all fields for the given step, and removes
+// step from step history.
+BaseController.prototype.invalidateStep = function invalidateStep(stepName, sessionModel) {
+  var step = this.options.steps[stepName] || {};
+  sessionModel.unset(step.fields);
+  var steps = _.without(sessionModel.get('steps'), stepName);
+  sessionModel.set('steps', steps);
 };
 
 BaseController.prototype.getErrorStep = function getErrorStep(err, req) {


### PR DESCRIPTION
- Added invalidateStep method which takes a step name and removes it from the sessionModel, it also unsets any fields on given step
- Added invalidatePath method with takes a blacklist and whitelist step and calls invalidateStep for every reachable step from the blacklist but not whiteList
- Hooked into fork condition execution - if truthy any steps reachable via `next` and not fork `target` are invalidated, if falsy any steps reachable via fork `target` and not `next` are invalidated.
