### PR TITLE
Allow automatic rendering of fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,47 @@ Template
 <div class="{{foo}}"></div>
 ```
 
+#### Exposes fields to templates
+
+Fields given in step config will be exposed to the template along with a mixin if defined in field config. This can be used with the [renderField](#renderField) mixin to programmatically generate templates.
+
+steps.js
+```js
+steps: {
+  'step-1': {
+    fields: [
+      'field-1',
+      'field-2'
+    ]
+  }
+}
+```
+
+fields.js
+```js
+fields: {
+  'field-1': {
+    mixin: 'input-text',
+    ...
+  },
+  'field-2': {
+    mixin: 'radio-group',
+    ...
+  }
+}
+```
+
+exposed to templates in format:
+```js
+fields: [{
+  key: 'field-1',
+  mixin: 'input-text'
+}, {
+  key: 'field-2',
+  mixin: 'radio-group'
+}]
+```
+
 #### Handles journey forking
 
 Each step definition accepts a `next` property, the value of which is the next route in the journey. By default, when the form is successfully submitted, the next steps will load. However, there are times when it is necessary to fork from the current journey based on a users response to certain questions in a form. For such circumstances there exists the `forks` property.
@@ -260,6 +301,20 @@ In config page template
 ```
 
 ------------------------------
+
+------------------------------
+
+## Mixins
+
+### renderField
+
+The renderField mixin can be called in your template with the field to render as the scope. This will lookup the field.mixin in res.locals and call it passing the field key.
+
+```html
+{{#fields}}
+  {{#renderField}}{{/renderField}}
+{{/fields}}
+```
 
 ## Test
 

--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -3,6 +3,7 @@
 var Controller = require('hmpo-form-wizard').Controller;
 var util = require('util');
 var _ = require('lodash');
+var lambdas = require('./mixins/lambdas');
 
 var BaseController = function BaseController(options) {
   this.confirmStep = options.confirmStep || '/confirm';
@@ -60,6 +61,11 @@ BaseController.prototype.getNextStep = function getNextStep(req, res) {
   return next;
 };
 
+BaseController.prototype.render = function render(req, res) {
+  lambdas(req, res);
+  Controller.prototype.render.apply(this, arguments);
+};
+
 BaseController.prototype.getErrorStep = function getErrorStep(err, req) {
   var redirect = Controller.prototype.getErrorStep.call(this, err, req);
   if (req.params.action === 'edit' && !redirect.match(/\/edit$/)) {
@@ -71,11 +77,18 @@ BaseController.prototype.getErrorStep = function getErrorStep(err, req) {
 BaseController.prototype.locals = function controllerLocals(req, res) {
   var locals = Controller.prototype.locals.apply(this, arguments);
   var stepLocals = this.options.locals || {};
+  var fields = _.map(this.options.fields, function mapFields(field, key) {
+    return {
+      key: key,
+      mixin: field.mixin
+    };
+  });
 
   return _.extend({}, locals, {
     baseUrl: req.baseUrl,
     nextPage: this.getNextStep(req, res),
-    errorLength: getErrorLength.apply(this, arguments)
+    errorLength: getErrorLength.apply(this, arguments),
+    fields: fields
   }, stepLocals);
 };
 

--- a/lib/mixins/lambdas.js
+++ b/lib/mixins/lambdas.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = function lambdas(req, res) {
+  Object.assign(res.locals, {
+    renderField: function renderField() {
+      return function renderFieldMixin() {
+        var mixin = this.mixin;
+        if (mixin && res.locals[mixin] && typeof res.locals[mixin] === 'function') {
+          return res.locals[mixin]().call(this, this.key);
+        }
+      };
+    }
+  });
+};

--- a/test/lib/base-controller.js
+++ b/test/lib/base-controller.js
@@ -20,7 +20,8 @@ describe('lib/base-controller', function () {
       });
       hmpoFormWizard.Controller.prototype.locals = sinon.stub().returns({foo: 'bar'});
       Controller = proxyquire('../../lib/base-controller', {
-        'hmpo-form-wizard': hmpoFormWizard
+        'hmpo-form-wizard': hmpoFormWizard,
+        './middleware/mixins': {}
       });
     });
 
@@ -72,6 +73,38 @@ describe('lib/base-controller', function () {
           .and.deep.equal({
             multiple: true
           });
+      });
+
+      describe('with fields', function () {
+        var locals;
+        beforeEach(function () {
+          controller.getErrors = sinon.stub().returns({foo: true});
+          controller.options.fields = {
+            'a-field': {
+              mixin: 'input-text'
+            },
+            'another-field': {
+              mixin: 'input-number'
+            }
+          };
+          locals = controller.locals(req, res);
+        });
+
+        it('should have added a fields array to return object', function () {
+          locals.should.have.property('fields').and.be.an('array');
+        });
+
+        it('should have added 2 items to the fields array', function () {
+          locals.fields.length.should.be.equal(2);
+        });
+
+        it('should have added \'a-field\' as \'key\' property to the first object', function () {
+          locals.fields[0].key.should.be.equal('a-field');
+        });
+
+        it('should have added \'input-text\' as \'mixin\' property to the first object', function () {
+          locals.fields[0].mixin.should.be.equal('input-text');
+        });
       });
 
       describe('with locals', function () {

--- a/test/lib/mixins/lambdas.js
+++ b/test/lib/mixins/lambdas.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var lambdas = require('../../../lib/mixins/lambdas');
+
+describe('Lambdas Mixins', function () {
+  var req = {};
+  var res = {
+    locals: {}
+  };
+  var next = sinon.stub();
+
+  beforeEach(function () {
+    lambdas(req, res, next);
+  });
+
+  it('should expose a renderField method via res.locals', function () {
+    res.locals.should.have.property('renderField').and.be.a('function');
+  });
+
+  describe('renderField', function () {
+    var renderField;
+
+    beforeEach(function () {
+      renderField = res.locals.renderField;
+    });
+
+    it('should return a function', function () {
+      renderField().should.be.a('function');
+    });
+
+    it('should lookup a mixin from res.locals and call it with key if found', function () {
+      var mixinStub = sinon.stub();
+      var renderFieldMixin = renderField();
+      var scope = {
+        key: 'a-key',
+        mixin: 'a-mixin'
+      };
+      res.locals['a-mixin'] = function() {
+        return mixinStub;
+      };
+      renderFieldMixin.call(scope);
+      mixinStub.should.have.been.calledOnce.and.calledWithExactly('a-key');
+    });
+  });
+});


### PR DESCRIPTION
### Background

Currently when creating a form with a number of steps, each step requires its own template file, even if the only difference is the field(s) on the page. This is because there currently isn't any way to iterate over a step's fields.

This PR exposes a `fields` array to res.locals for use in the templates so fields can be iterated over, and it also supplies a `renderField` lambda which is used to render the current field in scope.

current field rendering

``` html
{{#input-text}}field-1{{/input-text}}
{{#input-number}}field-2{{/input-number}}
{{#input-email}}field-3{{/input-email}}
```

with these changes:

``` html
{{#fields}}
  {{#renderField}}{{/renderField}}
{{/fields}}
```

This requires the field config to contain the mixin name:

fields.js

``` js
fields: {
  'field-1': {
    mixin: 'input-text',
    ...
  },
  'field-2': {
    mixin: 'input-number',
    ...
  },
  'field-3': {
    mixin: 'input-email',
    ...
  }
}
```
### Changes
- expose array of fields with keys and mixins to template
- added middleware/mixins which is applied in base controller constructor
- renderField lambda added which will render a field with the given mixin if called with the field as the scope (in an `fields` loop)
