### PR TITLE
closes #42 - remove node 0.12 from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
+  - "4.4.2"
   - "5"
 
 cache:


### PR DESCRIPTION
- removed node 0.12
- replaced with 4.2. CI versions are now 4, 4.2 and 5
