### PR TITLE
expose stepNumber in locals

### DIFF
--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -4,6 +4,35 @@ const Controller = require('hmpo-form-wizard').Controller;
 const _ = require('lodash');
 const lambdas = require('./mixins/lambdas');
 
+function getStepsJourney(route, stepsJourney, prevStep, steps) {
+  if (steps.indexOf('/') > -1) {
+    steps = _.without(steps, '/');
+  }
+  // remove any invalidated steps from journey
+  stepsJourney = _.intersection(stepsJourney, steps);
+  // add currentStep to journey if not
+  // already added
+  if (stepsJourney.indexOf(route) === -1) {
+    if (prevStep === undefined) {
+      stepsJourney.push(route);
+    } else {
+      // add current step after the prev step
+      // to preserve journey order
+      var prevIndex = stepsJourney.indexOf(prevStep);
+      stepsJourney.splice(prevIndex + 1, 0, route);
+    }
+  }
+
+  return stepsJourney;
+};
+
+function getCurrentStepNumber(route, stepsJourney) {
+  // find index of current step, return as
+  // 1-indexed for display.
+  return stepsJourney.indexOf(route) + 1;
+};
+
+
 module.exports = class BaseController extends Controller {
   constructor(options) {
     super(options);
@@ -67,8 +96,20 @@ module.exports = class BaseController extends Controller {
     const stepLocals = this.options.locals || {};
     const fields = _.map(this.options.fields, (field, key) => ({key, mixin: field.mixin}));
 
+    const stepData = req.sessionModel.get('stepData') || {};
+    const route = req.url.replace(/\/edit$/, '');
+    const steps = req.sessionModel.get('steps');
+    const stepsJourney = getStepsJourney(route, stepData.stepsJourney, stepData.prevStep, steps);
+    const stepNumber = getCurrentStepNumber(route, stepsJourney);
+
+    req.sessionModel.set('stepData', {
+      stepsJourney,
+      prevStep: route
+    });
+
     return _.extend({}, locals, {
       fields,
+      stepNumber,
       baseUrl: req.baseUrl,
       nextPage: this.getNextStep(req, res),
       errorLength: this.getErrorLength(req, res),

--- a/test/lib/confirm-controller.js
+++ b/test/lib/confirm-controller.js
@@ -56,6 +56,11 @@ describe('lib/confirm-controller', () => {
     let locals;
 
     beforeEach(() => {
+      req.url = '';
+      req.sessionModel = {
+        get: sinon.stub().returns([]),
+        set: sinon.stub()
+      };
       locals = controller.locals(req, res);
     });
 


### PR DESCRIPTION
- added a stepData object to sessionModel - this contains the previous step and the steps journey
- a step is added to the steps journey after the index of the previous step
- invalidated steps are removed from the journey to keep an accurate index
- stepNumber is exposed to locals which is the index of the current step in the journey, this is 1-indexed
