### PR TITLE
bugfix - pass locals to mixin

### DIFF
--- a/lib/mixins/lambdas.js
+++ b/lib/mixins/lambdas.js
@@ -6,7 +6,7 @@ module.exports = function lambdas(req, res) {
       return function renderFieldMixin() {
         const mixin = this.mixin;
         if (mixin && res.locals[mixin] && typeof res.locals[mixin] === 'function') {
-          return res.locals[mixin]().call(this, this.key);
+          return res.locals[mixin]().call(Object.assign({}, res.locals, this), this.key);
         }
       };
     }

--- a/test/lib/mixins/lambdas.js
+++ b/test/lib/mixins/lambdas.js
@@ -18,10 +18,19 @@ describe('Lambdas Mixins', () => {
   });
 
   describe('renderField', () => {
+    const scope = {
+      key: 'a-key',
+      mixin: 'a-mixin'
+    };
     let renderField;
+    let mixinStub;
+    let renderFieldMixin;
 
     beforeEach(() => {
       renderField = res.locals.renderField;
+      mixinStub = sinon.stub();
+      renderFieldMixin = renderField();
+      res.locals['a-mixin'] = () => mixinStub;
     });
 
     it('should return a function', () => {
@@ -29,15 +38,15 @@ describe('Lambdas Mixins', () => {
     });
 
     it('should lookup a mixin from res.locals and call it with key if found', () => {
-      const mixinStub = sinon.stub();
-      const renderFieldMixin = renderField();
-      const scope = {
-        key: 'a-key',
-        mixin: 'a-mixin'
-      };
-      res.locals['a-mixin'] = () => mixinStub;
       renderFieldMixin.call(scope);
       mixinStub.should.have.been.calledOnce.and.calledWithExactly('a-key');
+    });
+
+    it('exposes res.locals to the called mixin', () => {
+      mixinStub.returnsThis();
+      res.locals.foo = 'bar';
+      renderFieldMixin.call(scope);
+      mixinStub.returnValues[0].should.have.property('foo').and.equal('bar');
     });
   });
 });


### PR DESCRIPTION
res.locals weren't being passed to scope in renderField lambda - this resulted in the value not being persisted when a completed field is revisited
