### PR TITLE
backLinks strip /edit from url

### DIFF
--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -54,6 +54,18 @@ module.exports = class BaseController extends Controller {
     super.render(req, res);
   }
 
+  getBackLink(req, res) {
+    const backLink = res.locals.backLink;
+    const trailingEdit = req.params.action === 'edit' ? '/edit' : '';
+    const leadingSlash = /^\/?\w+/.test(req.baseUrl) ? '' : '/';
+
+    if (backLink === '') {
+      return backLink;
+    }
+
+    return `${leadingSlash}${backLink}${trailingEdit}`;
+  }
+
   getErrorStep(err, req) {
     let redirect = super.getErrorStep(err, req);
     if (req.params.action === 'edit' && !redirect.match(/\/edit$/)) {
@@ -70,6 +82,7 @@ module.exports = class BaseController extends Controller {
     return _.extend({}, locals, {
       fields,
       baseUrl: req.baseUrl,
+      backLink: this.getBackLink(req, res),
       nextPage: this.getNextStep(req, res),
       errorLength: this.getErrorLength(req, res),
     }, stepLocals);


### PR DESCRIPTION
- added `getBackLink` method to base controller - this is called by the locals method and alters the value of `res.locals.backLink`
- if `backLink` is empty string, do nothing
- if `req.params.action === edit`, append `/edit`
- if no `baseUrl`, prepend `/`
