### PR TITLE
So-master patch to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,64 @@ The renderField mixin can be called in your template with the field to render as
 {{/fields}}
 ```
 
+#### conditionally rendering fields
+
+`renderField` supports conditionally omitting fields if `useWhen` is passed in field config.  `useWhen` accepts another field key `String` and checks the value is `true`, or an `Object` with the keys `field` and `value`.  The field to check cannot appear on the same step - consider using the `toggle` property to show/hide a field on the same step.
+
+```js
+'field-1': {
+  useWhen: 'field-2'
+}
+```
+`field-1` will only be included if `field-2` value is `true`
+
+```js
+'field-3': {
+  useWhen: {
+    field: 'field-4',
+    value: 'a-value'
+  }
+}
+```
+`field-3` will only be included if `field-4` value is `a-value`
+
+##### Use case
+
+When a field on a multiple-step form is only to be included depending on the outcome of a previous answer. In the below example `dependant-field` is only included on step-2 if `dependent-radio` on step-1 is `'yes'`;
+
+steps.js
+```js
+{
+  '/step-1': {
+    fields: [
+      'dependent-radio'
+    ]
+  },
+  '/step-2': {
+    fields: [
+      'dependant-field',
+      'regular-field'
+    ]
+  }
+}
+```
+
+fields.js
+```js
+{
+  'dependent-radio': {
+    options: ['yes', 'no']
+  },
+  'dependant-field': {
+    useWhen: {
+      field: 'dependant-field',
+      value: 'yes'
+    }
+  },
+  'regular-field': {}
+}
+```
+
 ## Test
 
 ```bash

--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -54,6 +54,18 @@ module.exports = class BaseController extends Controller {
     super.render(req, res);
   }
 
+  getBackLink(req, res) {
+    const backLink = res.locals.backLink;
+    const trailingEdit = req.params.action === 'edit' ? '/edit' : '';
+    const leadingSlash = /^\/?\w+/.test(req.baseUrl) ? '' : '/';
+
+    if (backLink === '') {
+      return backLink;
+    }
+
+    return `${leadingSlash}${backLink}${trailingEdit}`;
+  }
+
   getErrorStep(err, req) {
     let redirect = super.getErrorStep(err, req);
     if (req.params.action === 'edit' && !redirect.match(/\/edit$/)) {
@@ -70,6 +82,7 @@ module.exports = class BaseController extends Controller {
     return _.extend({}, locals, {
       fields,
       baseUrl: req.baseUrl,
+      backLink: this.getBackLink(req, res),
       nextPage: this.getNextStep(req, res),
       errorLength: this.getErrorLength(req, res),
     }, stepLocals);

--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -77,7 +77,11 @@ module.exports = class BaseController extends Controller {
   locals(req, res) {
     const locals = super.locals(req, res);
     const stepLocals = this.options.locals || {};
-    const fields = _.map(this.options.fields, (field, key) => ({key, mixin: field.mixin}));
+    const fields = _.map(this.options.fields, (field, key) => ({
+      key,
+      mixin: field.mixin,
+      useWhen: field.useWhen
+    }));
 
     return _.extend({}, locals, {
       fields,

--- a/lib/mixins/lambdas.js
+++ b/lib/mixins/lambdas.js
@@ -5,6 +5,15 @@ module.exports = function lambdas(req, res) {
     renderField() {
       return function renderFieldMixin() {
         const mixin = this.mixin;
+        if (this.useWhen) {
+          const condition = typeof this.useWhen === 'string'
+            ? req.sessionModel.get(this.useWhen) === true
+            : req.sessionModel.get(this.useWhen.field) !== this.useWhen.value;
+          if (condition) {
+            req.sessionModel.unset(this.key);
+            return null;
+          }
+        }
         if (mixin && res.locals[mixin] && typeof res.locals[mixin] === 'function') {
           return res.locals[mixin]().call(Object.assign({}, res.locals, this), this.key);
         }


### PR DESCRIPTION
Patching so-master back to master. so-master not PR'd directly as it references so-master branch of hmpo form controller.

This PR includes the condition field inclusion feature https://github.com/UKHomeOffice/hof-controllers/pull/62 and a bugfix where backlinks were stripping /edit from the url: https://github.com/UKHomeOffice/hof-controllers/pull/62
