### PR TITLE
closes #68 - use default template if options.template doesn't exist

### DIFF
--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -10,6 +10,15 @@ module.exports = class BaseController extends Controller {
     this.confirmStep = options.confirmStep || '/confirm';
   }
 
+  get(req, res, callback) {
+    res.render(this.options.template, err => {
+      if (err && err.message.match(/^Failed to lookup view/)) {
+        this.options.template = res.locals.partials.step;
+      }
+    });
+    super.get(req, res, callback);
+  }
+
   getNextStep(req, res) {
     let next = super.getNextStep(req, res);
     const forks = this.options.forks || [];

--- a/test/lib/base-controller.js
+++ b/test/lib/base-controller.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const proxyquire = require('proxyquire');
 
 describe('lib/base-controller', () => {
@@ -39,6 +40,43 @@ describe('lib/base-controller', () => {
       Controller = proxyquire('../../lib/base-controller', {
         'hmpo-form-wizard': hmpoFormWizard
       });
+    });
+
+    describe('.get()', () => {
+      const req = {};
+      const res = {
+        locals: {
+          partials: {
+            step: 'default-template'
+          }
+        }
+      };
+
+      beforeEach(() => {
+        res.render = sinon.stub();
+        hmpoFormWizard.Controller.prototype.get = sinon.stub();
+        controller = new Controller({
+          template: 'foo'
+        });
+      });
+
+      it('calls super', () => {
+        controller.get(req, res, _.noop);
+        hmpoFormWizard.Controller.prototype.get.should.have.been.calledOnce
+          .and.calledWithExactly(req, res, _.noop);
+      });
+
+      it('calls res.render with the template', () => {
+        controller.get(req, res, _.noop);
+        res.render.should.have.been.calledOnce;
+      });
+
+      it('sets template to res.locals.partials.step if view lookup error', () => {
+        res.render = (template, cb) => cb(new Error('Failed to lookup view'));
+        controller.get(req, res, _.noop);
+        controller.options.template.should.be.equal('default-template');
+      });
+
     });
 
     describe('.getBackLink()', () => {


### PR DESCRIPTION
- Try looking up template, if fails with lookup error, use res.locals.partials.step

In many cases a step will consist of rendering all fields and meta with a continue button - a default partial 'step.html' has been added to hof-template-partials and this change causes the default to be rendered if the given template cant be found (no template supplied, no template with same name as step exists)
