### PR TITLE
bugfix - cast template to string when performing check

### DIFF
--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -11,7 +11,8 @@ module.exports = class BaseController extends Controller {
   }
 
   get(req, res, callback) {
-    res.render(this.options.template, err => {
+    const template = this.options.template || '';
+    res.render(template, err => {
       if (err && err.message.match(/^Failed to lookup view/)) {
         this.options.template = res.locals.partials.step;
       }


### PR DESCRIPTION
- if res.locals.partials.step is undefined then template is set as undefined and we try to render `undefined` next time round. This should be cast as string so as not to throw error
