### PR TITLE
Bugfix - prevent reset session race condition

### DIFF
--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -103,13 +103,18 @@ module.exports = class BaseController extends Controller {
   }
 
   getValues(req, res, callback) {
-    super.getValues(req, res, callback);
-    const noNext = _.isUndefined(this.options.next);
-    const clearSession = this.options.clearSession;
-    // clear the session if there's no next step or we request to clear the session
-    if ((noNext && clearSession !== false) || clearSession === true) {
-      req.sessionModel.reset();
-    }
+    super.getValues(req, res, err => {
+      if (err) {
+        return callback(err);
+      }
+      const noNext = _.isUndefined(this.options.next);
+      const clearSession = this.options.clearSession;
+      // clear the session if there's no next step or we request to clear the session
+      if ((noNext && clearSession !== false) || clearSession === true) {
+        req.sessionModel.reset();
+      }
+      callback();
+    });
   }
 
   getErrorLength(req, res) {


### PR DESCRIPTION
There is a potential race condition in the `BaseController.getValues` function. Looks like it’s possible for the `super.getValues` function to call the callback, which calls the following middleware functions and sends the response, before the session has been reset.

The following has been done to fix this issue: -
- defer the callback for the next middleware function until after the check for resetting the session
- handle error returned from parent controller `getValues` by immediately firing the callback with the error
