### PR TITLE
Bugfix - if edit is in the url, don't append edit

### DIFF
--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -78,7 +78,7 @@ module.exports = class BaseController extends Controller {
 
   getErrorStep(err, req) {
     let redirect = super.getErrorStep(err, req);
-    if (req.params.action === 'edit' && !redirect.match(/\/edit$/)) {
+    if (req.params.action === 'edit' && !redirect.match(/\/edit$|\/edit\//)) {
       redirect += '/edit';
     }
     return redirect;

--- a/test/lib/base-controller.js
+++ b/test/lib/base-controller.js
@@ -662,7 +662,13 @@ describe('lib/base-controller', () => {
       describe('when the action is "edit" and the parent redirect is not edit', () => {
         it('appends "edit" to the path', () => {
           req.params.action = 'edit';
-          controller.getErrorStep(err, req).should.contain('/edit');
+          controller.getErrorStep(err, req).should.match(/\/edit$/);
+        });
+
+        it('doesn\'t append "edit" to the path if "edit" is already present', () => {
+          req.params.action = 'edit';
+          hmpoFormWizard.Controller.prototype.getErrorStep.returns('/a-path/edit/id');
+          controller.getErrorStep(err, req).should.not.match(/\/edit$/);
         });
       });
 


### PR DESCRIPTION
This casues a bug when you are editing a specifig record - /path/edit/{id}
