### PR TITLE
bugfix - pass errorValues to callback in getValues function

### DIFF
--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -103,9 +103,9 @@ module.exports = class BaseController extends Controller {
   }
 
   getValues(req, res, callback) {
-    super.getValues(req, res, err => {
+    super.getValues(req, res, (err, values) => {
       if (err) {
-        return callback(err);
+        return callback(err, values);
       }
       const noNext = _.isUndefined(this.options.next);
       const clearSession = this.options.clearSession;
@@ -113,7 +113,7 @@ module.exports = class BaseController extends Controller {
       if ((noNext && clearSession !== false) || clearSession === true) {
         req.sessionModel.reset();
       }
-      callback();
+      return callback(null, values);
     });
   }
 


### PR DESCRIPTION
This functionality was broken in a previous commit. On error the form values should be persisted to prevent the user from having to enter them again
- pass values from super call to callback as second arg
- return callback (consistent return)
