### PR TITLE
Pass the request object to the modifier function

### DIFF
--- a/lib/confirm-controller.js
+++ b/lib/confirm-controller.js
@@ -21,14 +21,14 @@ function getStepFromFieldName(fieldName, steps) {
  * of field objects made up of field name,
  * value and step
  */
-const getFieldObjectsFromNames = (fields, values, modifiers, steps) =>
+const getFieldObjectsFromNames = (fields, values, modifiers, steps, req) =>
   fields.filter(item => {
     return (values[item] !== undefined && values[item] !== '') || modifiers[item] !== undefined;
   }).map(name => {
     let value = values[name];
     const step = getStepFromFieldName(name, steps);
     if (modifiers[name]) {
-      value = modifiers[name](values);
+      value = modifiers[name](value, req);
     }
     return {name, value, step};
   });
@@ -45,7 +45,8 @@ module.exports = class ConfirmController extends BaseController {
         section.fields,
         res.locals.values,
         config.modifiers || {},
-        steps
+        steps,
+        req
       );
     });
 

--- a/test/lib/confirm-controller.js
+++ b/test/lib/confirm-controller.js
@@ -11,10 +11,13 @@ const ConfirmController = proxyquire('../../lib/confirm-controller', {
 
 describe('lib/confirm-controller', () => {
   const req = {
-    params: {}
+    params: {},
+    translate: function () {}
   };
   const res = {};
   let controller;
+
+  const modifierSpy = sinon.spy((value) => value * 3);
 
   beforeEach(() => {
     controller = new ConfirmController({
@@ -47,7 +50,10 @@ describe('lib/confirm-controller', () => {
             'field-three',
             'field-four'
           ]
-        }]
+        }],
+        modifiers: {
+          'field-two': modifierSpy
+        }
       }
     };
   });
@@ -95,6 +101,14 @@ describe('lib/confirm-controller', () => {
 
       it('should have set step: /one on the field object', () => {
         fields[0].should.have.property('step').and.equal('/one');
+      });
+
+      it('should use modifiers', () => {
+        fields[1].should.have.property('value').and.equal(6);
+      });
+
+      it('should call modifiers with the value of the field and the request', () => {
+        modifierSpy.should.have.been.calledWith(res.locals.values['field-two'], req);
       });
 
       it('should have set value 3 on the 3rd field object', () => {


### PR DESCRIPTION
This change will mean we can use the re.translate function in a modifier function
