### PR TITLE
Enhancement - pass rawValue to template in confirm controller (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ In config page template
 
 ```html
 {{#tableSections}}
-  {{> partials-summary-table}} <!-- {{name}}, {{value}} and {{step}} are available in this scope -->
+  {{> partials-summary-table}} <!-- {{name}}, {{value}}, {{origValue}} and {{step}} are available in this scope -->
 {{/tableSections}}
 ```
 

--- a/lib/confirm-controller.js
+++ b/lib/confirm-controller.js
@@ -19,18 +19,24 @@ function getStepFromFieldName(fieldName, steps) {
 /*
  * Utility function to create an array
  * of field objects made up of field name,
- * value and step
+ * value, origValue and step
  */
 const getFieldObjectsFromNames = (fields, values, modifiers, steps, req) =>
   fields.filter(item => {
     return (values[item] !== undefined && values[item] !== '') || modifiers[item] !== undefined;
   }).map(name => {
-    let value = values[name];
     const step = getStepFromFieldName(name, steps);
+    let fieldObject = {
+      name,
+      step,
+      origValue: values[name],
+      value: values[name]
+    };
     if (modifiers[name]) {
-      value = modifiers[name](value, req);
+      // this inside modifier has access to fieldObject
+      fieldObject.value = modifiers[name].call(fieldObject, fieldObject.value, req);
     }
-    return {name, value, step};
+    return fieldObject;
   });
 
 module.exports = class ConfirmController extends BaseController {

--- a/test/lib/confirm-controller.js
+++ b/test/lib/confirm-controller.js
@@ -107,6 +107,10 @@ describe('lib/confirm-controller', () => {
         fields[1].should.have.property('value').and.equal(6);
       });
 
+      it('passes raw value', () => {
+        fields[1].should.have.property('origValue').and.equal(2);
+      });
+
       it('should call modifiers with the value of the field and the request', () => {
         modifierSpy.should.have.been.calledWith(res.locals.values['field-two'], req);
       });


### PR DESCRIPTION
- Enhancement - pass rawValue to template in confirm controller

Modifier functions can be passed to confirm controller to format or translate values, but it would be useful to be able to access the raw unformatted value.
- pass new rawValue variable to template which is not put through modifier function
- updated README
- added test
- rawValue > origValue. Also refactored to call modifier with scope of field object
