### PR TITLE
bugfix - don't include empty values in confirm controller

### DIFF
--- a/lib/confirm-controller.js
+++ b/lib/confirm-controller.js
@@ -22,9 +22,7 @@ function getStepFromFieldName(fieldName, steps) {
  * value, origValue and step
  */
 const getFieldObjectsFromNames = (fields, values, modifiers, steps, req) =>
-  fields.filter(item => {
-    return (values[item] !== undefined && values[item] !== '') || modifiers[item] !== undefined;
-  }).map(name => {
+  fields.filter(item => values[item] !== undefined && values[item] !== '').map(name => {
     const step = getStepFromFieldName(name, steps);
     let fieldObject = {
       name,


### PR DESCRIPTION
For some reason we were filtering out empy values, except for when there is a modifier for that value. I can't see a use case where we would desire this behaviour, and it results in the modifier being called on the empy field and included in the results.
