### PR TITLE
bugfix - reject empty sections

### DIFF
--- a/lib/confirm-controller.js
+++ b/lib/confirm-controller.js
@@ -41,8 +41,8 @@ module.exports = class ConfirmController extends BaseController {
   locals(req, res) {
     const locals = super.locals(req, res);
     const config = _.cloneDeep(this.options).config || {};
-    const tableSections = config.tableSections || [];
     const steps = this.options.steps;
+    let tableSections = config.tableSections || [];
 
     tableSections.forEach((section, index, array) => {
       array[index].fields = getFieldObjectsFromNames(
@@ -52,6 +52,10 @@ module.exports = class ConfirmController extends BaseController {
         steps,
         req
       );
+    });
+
+    tableSections = _.reject(tableSections, section => {
+      return !section.fields.length;
     });
 
     return _.extend({}, locals, {tableSections});

--- a/test/lib/confirm-controller.js
+++ b/test/lib/confirm-controller.js
@@ -50,6 +50,12 @@ describe('lib/confirm-controller', () => {
             'field-three',
             'field-four'
           ]
+        }, {
+          name: 'another-test',
+          fields: [
+            'field-five',
+            'field-six'
+          ]
         }],
         modifiers: {
           'field-two': modifierSpy


### PR DESCRIPTION
If a section doesn't contain any completed fields, it should be rejected from tableSections so it isn't rendered as a header
