### PR TITLE
Feature - implied title and intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Or override in step options
 
 Adds `single` or `multiple` to the locals to describe the number of errors for pluralisation of error messages.
 
+#### Locals for page info
+
+* Exposes `route` name to template (without preceding slash)
+* Exposes `title` to template if found in translations. Looked up in the order:  `pages.{route}.title -> fields.{firstFieldName}.label -> fields.{firstFieldName}.legend`.
+* Exposes `intro` to template if found in translations at `pages.{route}.intro`
+
 #### Exposes meta to templates
 
 Add a locals object to step config to expose configurable key/value pairs in the template. Useful for generating template partials programmatically. These will override any locals provided further up the tree.

--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -1,7 +1,10 @@
 'use strict';
 
-const Controller = require('hmpo-form-wizard').Controller;
 const _ = require('lodash');
+const i18nLookup = require('i18n-lookup');
+const Mustache = require('mustache');
+const helpers = require('./util/helpers');
+const Controller = require('hmpo-form-wizard').Controller;
 const lambdas = require('./mixins/lambdas');
 
 module.exports = class BaseController extends Controller {
@@ -85,8 +88,11 @@ module.exports = class BaseController extends Controller {
   }
 
   locals(req, res) {
+    const lookup = i18nLookup(req.translate, Mustache.render);
+    const route = this.options.route.replace(/^\//, '');
     const locals = super.locals(req, res);
     const stepLocals = this.options.locals || {};
+
     const fields = _.map(this.options.fields, (field, key) => ({
       key,
       mixin: field.mixin,
@@ -95,7 +101,10 @@ module.exports = class BaseController extends Controller {
 
     return _.extend({}, locals, {
       fields,
+      route,
       baseUrl: req.baseUrl,
+      title: helpers.getTitle(route, lookup, this.options.fields, res.locals),
+      intro: helpers.getIntro(route, lookup, res.locals),
       backLink: this.getBackLink(req, res),
       nextPage: this.getNextStep(req, res),
       errorLength: this.getErrorLength(req, res),

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -25,6 +25,42 @@ module.exports = class Helpers {
   }
 
   /**
+   * Helper function to lookup and return the page title
+   * translation if found. If not it will fallback to the
+   * label or legend of the first field on the page
+   * @param {String} route - the route of the step
+   * @param {Function} lookup - i18n-lookup bound to translate and Mustache.render
+   * @param {Object} fields - a key:value map of step fields
+   * @param {Object} locals - the locals map for mustache rendering
+   * @returns {String} - the first translation found
+   */
+  static getTitle(route, lookup, fields, locals) {
+     let fieldName = '';
+     if (_.size(fields)) {
+       fieldName = Object.keys(fields)[0];
+     }
+     return lookup([
+       `pages.${route}.header`,
+       `fields.${fieldName}.label`,
+       `fields.${fieldName}.legend`
+     ], locals);
+   }
+
+  /**
+   * Helper function to return intro if
+   * located in pages.{route}.intro
+   * @param {String} route - the route of the step
+   * @param {Function} lookup - i18n-lookup bound to translate and Mustache.render
+   * @param {Object} locals - the locals map for mustache rendering
+   * @returns {String} the translation if found
+   */
+  static getIntro(route, lookup, locals) {
+     return lookup([
+       `pages.${route}.intro`
+     ], locals);
+   }
+
+  /**
    * Utility function which returns true
    * if a field type has associated options
    * @param {String} mixin - the name of the mixin
@@ -39,8 +75,8 @@ module.exports = class Helpers {
    * fields that have options
    * @param {Function} translate - translate function
    * @param {String} field - the id of the field
-   * @param {any} value - the value of the field
-   * @returns {any} the translation of the label if found,
+   * @param {String} value - the value of the field
+   * @returns {String} the translation of the label if found,
    * the raw value if not
    */
    static getValue(translate, field, value) {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   "dependencies": {
     "hmpo-form-wizard": "https://github.com/UKHomeOffice/passports-form-wizard.git#so-master",
     "hof-emailer": "^1.0.0",
+    "i18n-lookup": "^0.1.0",
     "lodash": "4.16.3",
-    "moment": "2.15.1"
+    "moment": "2.15.1",
+    "mustache": "^2.3.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",

--- a/test/lib/base-controller.js
+++ b/test/lib/base-controller.js
@@ -16,8 +16,8 @@ describe('lib/base-controller', () => {
   describe('constructor', () => {
 
     beforeEach(() => {
-      hmpoFormWizard.Controller = sinon.stub(hmpoFormWizard, 'Controller', function () {
-        this.options = {};
+      hmpoFormWizard.Controller = sinon.stub(hmpoFormWizard, 'Controller', function (options) {
+        this.options = options;
       });
       hmpoFormWizard.Controller.prototype.locals = sinon.stub().returns({foo: 'bar'});
       Controller = proxyquire('../../lib/base-controller', {
@@ -27,7 +27,9 @@ describe('lib/base-controller', () => {
     });
 
     it('calls the parent constructor', () => {
-      controller = new Controller({template: 'foo'});
+      controller = new Controller({
+        template: 'foo'
+      });
       hmpoFormWizard.Controller.should.have.been.called;
     });
 
@@ -38,7 +40,10 @@ describe('lib/base-controller', () => {
     beforeEach(() => {
       hmpoFormWizard.Controller.prototype.getNextStep = sinon.stub();
       Controller = proxyquire('../../lib/base-controller', {
-        'hmpo-form-wizard': hmpoFormWizard
+        'hmpo-form-wizard': hmpoFormWizard,
+        'i18n-lookup': function() {
+          return function () {};
+        }
       });
     });
 
@@ -146,7 +151,8 @@ describe('lib/base-controller', () => {
         sinon.stub(Controller.prototype, 'getErrorLength');
         Controller.prototype.getErrorLength.returns({single: true});
         controller = new Controller({
-          template: 'foo'
+          template: 'foo',
+          route: '/bar'
         });
       });
 
@@ -231,7 +237,8 @@ describe('lib/base-controller', () => {
             },
             locals: {
               test: 'bar',
-            }
+            },
+            route: '/baz'
           };
         });
 

--- a/test/lib/util/helpers.js
+++ b/test/lib/util/helpers.js
@@ -1,8 +1,23 @@
 'use strict';
 
-const helpers = require('../../../lib/util/helpers');
+const proxyquire = require('proxyquire');
 
 describe('Helpers', () => {
+  let helpers;
+  let hoganStub;
+  let renderStub;
+  beforeEach(() => {
+    renderStub = sinon.stub();
+    hoganStub = {
+      compile: sinon.stub().returns({
+        render: renderStub
+      })
+    };
+    helpers = proxyquire('../../../lib/util/helpers', {
+      'hogan.js': hoganStub
+    });
+  });
+
   describe('getStepFromFieldName()', () => {
     let steps;
     beforeEach(() => {
@@ -58,6 +73,54 @@ describe('Helpers', () => {
 
     it('returns false when called with false', () => {
       helpers.isEmptyValue(false).should.be.false;
+    });
+  });
+
+  describe('getTitle()', () => {
+    let lookup;
+    let fields;
+    beforeEach(() => {
+      lookup = sinon.stub();
+      fields = {
+        'field-one': {}
+      };
+    });
+
+    it('calls lookup with the correct list of keys', () => {
+      const expected = [
+        'pages.step-one.header',
+        'fields.field-one.label',
+        'fields.field-one.legend'
+      ];
+      helpers.getTitle('step-one', lookup, fields);
+      lookup.firstCall.args[0].should.be.deep.equal(expected);
+    });
+
+    it('passes the locals hash to lookup as second arg', () => {
+      const locals = {};
+      helpers.getTitle('step-one', lookup, fields, locals);
+      lookup.firstCall.args[1].should.be.equal(locals);
+    });
+  });
+
+  describe('getIntro()', () => {
+    let lookup;
+    beforeEach(() => {
+      lookup = sinon.stub();
+    });
+
+    it('calls lookup with the correct list of keys', () => {
+      const expected = [
+        'pages.step-one.intro'
+      ];
+      helpers.getIntro('step-one', lookup);
+      lookup.firstCall.args[0].should.be.deep.equal(expected);
+    });
+
+    it('passes locals too lookup as second arg', () => {
+      const locals = {};
+      helpers.getIntro('step-one', lookup, locals);
+      lookup.firstCall.args[1].should.be.equal(locals);
     });
   });
 


### PR DESCRIPTION
This change extends the locals method of baseController providing route (without preceeding slash), title and intro.

Title is looked up in the following order:
```js
pages.{routeName}.header -> fields.{firstFieldName}.label -> fields.{firstFieldName}.legend
```

Intro is looked up using `pages.{routeName}.intro`

Added i18n-lookup lib for translation lookups, added mustache for interpolation in translations