### PR TITLE
bugfix - ignore duplicate fields

### DIFF
--- a/lib/confirm-controller.js
+++ b/lib/confirm-controller.js
@@ -39,6 +39,7 @@ module.exports = class ConfirmController extends BaseController {
           .reject(field => (fields[field] &&
             fields[field].includeInSummary === false) ||
             helpers.isEmptyValue(data[field]))
+          .uniq()
           .map(field => ({
             field,
             step: helpers.getStepFromFieldName(field, steps),

--- a/test/fixtures/steps.js
+++ b/test/fixtures/steps.js
@@ -53,7 +53,7 @@ module.exports = {
   },
   '/additional-2': {
     fields: [
-      'additions-names'
+      'additional-names'
     ],
     locals: {
       section: 'enquiry-details'

--- a/test/fixtures/steps.js
+++ b/test/fixtures/steps.js
@@ -51,6 +51,14 @@ module.exports = {
       section: 'enquiry-details'
     }
   },
+  '/additional-2': {
+    fields: [
+      'additions-names'
+    ],
+    locals: {
+      section: 'enquiry-details'
+    }
+  },
   '/how': {
     fields: [
       'how-radio',

--- a/test/lib/confirm-controller.js
+++ b/test/lib/confirm-controller.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const path = require('path');
 const proxyquire = require('proxyquire');
 const i18nFuture = require('i18n-future');
@@ -54,6 +55,14 @@ describe('Confirm Controller', () => {
           fields: [
             'field-2',
             'field-x'
+          ],
+          locals: {
+            section: 'section-1'
+          }
+        },
+        'step-2a': {
+          fields: [
+            'field-2'
           ],
           locals: {
             section: 'section-1'
@@ -180,6 +189,10 @@ describe('Confirm Controller', () => {
             result.should.have.property('fields')
               .and.have.property('length')
               .and.be.equal(3);
+          });
+
+          it('doesn\'t contain any duplicate fields', () => {
+            _.uniq(result.fields).should.be.deep.equal(result.fields);
           });
 
           describe('fields', () => {


### PR DESCRIPTION
If a field appears on multiple steps in the same section, only the first one should be used. This is a bug which occurs when a journey has a potential alternate step containaing one or more fields that could be in a different part of the journey