### PR TITLE
enhancement - allow email subject to be an object

### DIFF
--- a/lib/confirm-controller.js
+++ b/lib/confirm-controller.js
@@ -98,7 +98,7 @@ module.exports = class ConfirmController extends BaseController {
   getEmailerConfig(req) {
     const config = Object.assign({}, this.options.emailConfig, {
       data: this.formattedData,
-      subject: helpers.conditionalTranslate(req.translate, 'pages.email.subject'),
+      subject: helpers.conditionalTranslate(req.rawTranslate, 'pages.email.subject'),
       customerIntro: helpers.conditionalTranslate(req.translate, 'pages.email.intro.customer'),
       caseworkerIntro: helpers.conditionalTranslate(req.translate, 'pages.email.intro.caseworker'),
       customerOutro: helpers.conditionalTranslate(req.translate, 'pages.email.outro.customer'),

--- a/test/lib/confirm-controller.js
+++ b/test/lib/confirm-controller.js
@@ -316,6 +316,7 @@ describe('Confirm Controller', () => {
       describe('getEmailerConfig', () => {
         beforeEach(() => {
           req.sessionModel.get = sinon.stub().returns('sterling@archer.com');
+          req.rawTranslate = sinon.stub();
           confirmController.options = {
             emailConfig: {
               port: ''
@@ -345,6 +346,11 @@ describe('Confirm Controller', () => {
             caseworkerOutro: 'caseworker-outro',
             customerEmail: 'sterling@archer.com'
           });
+        });
+
+        it('passes rawTranslate when translating subject', () => {
+          confirmController.getEmailerConfig(req);
+          helpersStub.conditionalTranslate.firstCall.should.have.been.calledWith(req.rawTranslate);
         });
 
         it('doesn\'t include customerEmail if emailUser is false', () => {


### PR DESCRIPTION
req.translate uses deepTranslate middleware which attempts to resolve objects returned from translations. Raw translate will return the object, this is useful if we have a different subject for caseworker and customer