### PR TITLE
chore - updated helpers.getTranslation to use i18n-lookup

### DIFF
--- a/lib/confirm-controller.js
+++ b/lib/confirm-controller.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const _ = require('lodash');
+const i18nLookup = require('i18n-lookup');
+const Mustache = require('mustache');
 const BaseController = require('./base-controller');
 const helpers = require('./util/helpers');
 const Emailer = require('hof-emailer');
@@ -25,6 +27,7 @@ module.exports = class ConfirmController extends BaseController {
   formatData(data, translate) {
     const steps = this.options.steps;
     const fields = this.options.fieldsConfig;
+    const lookup = i18nLookup(translate, Mustache.render);
     return _(steps)
       .reject(step => !step.locals || !step.fields || _.every(
         step.fields,
@@ -32,7 +35,7 @@ module.exports = class ConfirmController extends BaseController {
       ))
       .groupBy(step => step.locals.section)
       .map((groupedSteps, section) => ({
-        section: helpers.getTranslation(translate, section),
+        section: helpers.getTranslation(lookup, section),
         fields: _(groupedSteps)
           .map('fields')
           .flatten()
@@ -43,7 +46,7 @@ module.exports = class ConfirmController extends BaseController {
           .map(field => ({
             field,
             step: helpers.getStepFromFieldName(field, steps, data.steps),
-            label: helpers.getTranslation(translate, field, true),
+            label: helpers.getTranslation(lookup, field, true),
             value: helpers.hasOptions(fields[field].mixin) ?
               helpers.getValue(translate, field, data[field]) :
               data[field]

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -111,34 +111,22 @@ module.exports = class Helpers {
    *
    * If the translation is not for a field it will first try pages.key.summary,
    * if this fails it will fallback to pages.keys.header.
-   * @param {Function} translate - translate function
+   * @param {Function} lookup - i18n lookup bound to translate
    * @param {String} key - the key of the field/page
    * @param {Boolean} isField - if the translation is for a field
    * @return {String} the result of the translation
    */
-  static getTranslation(translate, key, isField) {
-    const base = isField ? 'fields' : 'pages';
-    let path = `${base}.${key}.summary`;
-    let result = translate(path);
-    if (result === path) {
-      if (isField) {
-        path = `${base}.${key}.label`;
-        result = translate(path);
-        if (result === path) {
-          path = `${base}.${key}.legend`;
-          result = translate(path);
-          if (result === path) {
-            return key;
-          }
-        }
-      } else {
-        path = `${base}.${key}.header`;
-        result = translate(path);
-        if (result === path) {
-          return key;
-        }
-      }
+  static getTranslation(lookup, key, isField) {
+    if (isField) {
+      return lookup([
+        `fields.${key}.summary`,
+        `fields.${key}.label`,
+        `fields.${key}.legend`
+      ]) || key;
     }
-    return result;
+    return lookup([
+      `pages.${key}.summary`,
+      `pages.${key}.header`,
+    ]) || key;
   }
 };

--- a/test/lib/confirm-controller.js
+++ b/test/lib/confirm-controller.js
@@ -19,7 +19,7 @@ describe('Confirm Controller', () => {
   beforeEach(() => {
     StubController.prototype.locals = sinon.stub().returns({});
     StubController.prototype.get = sinon.stub();
-    EmailerStub.prototype.sendEmails = sinon.stub().returns(new Promise(resolve => resolve()));
+    EmailerStub.prototype.sendEmails = sinon.stub().returns(Promise.resolve());
     /* eslint-disable no-underscore-dangle */
     EmailerStub.prototype._initApp = sinon.stub();
     EmailerStub.prototype._initEmailer = sinon.stub();
@@ -390,7 +390,7 @@ describe('Confirm Controller', () => {
 
         it('calls callback with err on error', done => {
           const error = new Error('oops');
-          EmailerStub.prototype.sendEmails.returns(new Promise((resolve, reject) => reject(error)));
+          EmailerStub.prototype.sendEmails.returns(Promise.reject(error));
           confirmController.saveValues(req, res, err => {
             err.should.be.equal(error);
             done();

--- a/test/lib/util/helpers.js
+++ b/test/lib/util/helpers.js
@@ -197,68 +197,36 @@ describe('Helpers', () => {
   });
 
   describe('getTranslation()', () => {
-    it('returns the key if lookup fails', () => {
-      function translate(key) {
-        return key;
-      }
-      helpers.getTranslation(translate, 'a-key').should.be.equal('a-key');
+    let lookup;
+    beforeEach(() => {
+      lookup = sinon.stub();
     });
-  });
 
-  it('returns the summary value for page if it exists', () => {
-    function translate(key) {
-      if (key === 'pages.page.summary') {
-        return 'summary';
-      }
-    }
-    helpers.getTranslation(translate, 'page').should.be.equal('summary');
-  });
+    it('calls lookup with the correct keys if not a field', () => {
+      helpers.getTranslation(lookup, 'a-key');
+      lookup.should.have.been.calledWith([
+        'pages.a-key.summary',
+        'pages.a-key.header'
+      ]);
+    });
 
-  it('returns the header value for page if summary lookup fails', () => {
-    function translate(key) {
-      if (key === 'pages.page.summary') {
-        return 'pages.page.summary';
-      }
-      if (key === 'pages.page.header') {
-        return 'header';
-      }
-    }
-    helpers.getTranslation(translate, 'page').should.be.equal('header');
-  });
+    it('returns the key if lookup fails', () => {
+      lookup.returns(null);
+      helpers.getTranslation(lookup, 'a-key').should.be.equal('a-key');
+    });
 
-  it('returns the summary value for a field if exists', () => {
-    function translate(key) {
-      if (key === 'fields.field.summary') {
-        return 'summary';
-      }
-    }
-    helpers.getTranslation(translate, 'field', true).should.be.equal('summary');
-  });
+    it('calls lookup with the correct keys if a field', () => {
+      helpers.getTranslation(lookup, 'a-key', true);
+      lookup.should.have.been.calledWith([
+        'fields.a-key.summary',
+        'fields.a-key.label',
+        'fields.a-key.legend'
+      ]);
+    });
 
-  it('returns the label value for field if summary lookup fails', () => {
-    function translate(key) {
-      if (key === 'fields.field.summary') {
-        return 'fields.field.summary';
-      }
-      if (key === 'fields.field.label') {
-        return 'label';
-      }
-    }
-    helpers.getTranslation(translate, 'field', true).should.be.equal('label');
-  });
-
-  it('returns the legend value for field if summary and label lookups fail', () => {
-    function translate(key) {
-      if (key === 'fields.field.summary') {
-        return 'fields.field.summary';
-      }
-      if (key === 'fields.field.label') {
-        return 'fields.field.label';
-      }
-      if (key === 'fields.field.legend') {
-        return 'legend';
-      }
-    }
-    helpers.getTranslation(translate, 'field', true).should.be.equal('legend');
+    it('returns the key if lookup fails', () => {
+      lookup.returns(null);
+      helpers.getTranslation(lookup, 'a-key', true).should.be.equal('a-key');
+    });
   });
 });


### PR DESCRIPTION
* use i18n lib for looking up first matching key
* shorthand for `new Promise((resolve, reject) => resolve())` -> `Promise.resolve()`