### PR TITLE
Feature/include checkbox group formatted data

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -80,13 +80,19 @@ module.exports = class Helpers {
    * @returns {String} the translation of the label if found,
    * the raw value if not
    */
-   static getValue(translate, field, value) {
-     let key = `fields.${field}.options.${value}.label`;
-     let result = translate(key);
-     if (result !== key) {
-       return result;
-     }
-     return value;
+  static getValue(translate, field, values) {
+    if (!Array.isArray(values)) {
+      values = [values];
+    }
+    values.forEach((value, index) => {
+      let key = `fields.${field}.options.${value}.label`;
+      let result = translate(key);
+      if (result === key) {
+        result = value;
+      }
+      values[index] = result;
+    });
+    return values.join('\n');
   }
 
   /**

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -29,5 +29,6 @@ module.exports = {
   'when-date-day': '01',
   'when-date-month': '01',
   'when-date-year': '2001',
-  'which-radio': 'recorded'
+  'which-radio': 'recorded',
+  'which-checkbox': ['value-one', 'value-two']
 };

--- a/test/fixtures/fields.js
+++ b/test/fixtures/fields.js
@@ -50,5 +50,12 @@ module.exports = {
   },
   'which-radio': {
     mixin: 'radio-group'
+  },
+  'which-checkbox': {
+    mixin: 'checkbox-group',
+    options: [
+      'value-one',
+      'value-two'
+    ]
   }
 };

--- a/test/fixtures/output.js
+++ b/test/fixtures/output.js
@@ -144,6 +144,12 @@ module.exports = [
         label: 'Address Textarea',
         step: '/address',
         value: '123 Example Street, Croydon'
+      },
+      {
+        field: 'which-checkbox',
+        label: 'Which Checkbox',
+        step: '/address',
+        value: 'First value\nSecond value'
       }
     ],
     section: 'Contact Details'

--- a/test/fixtures/steps.js
+++ b/test/fixtures/steps.js
@@ -130,7 +130,8 @@ module.exports = {
   },
   '/address': {
     fields: [
-      'address-textarea'
+      'address-textarea',
+      'which-checkbox'
     ],
     locals: {
       section: 'contact-details',

--- a/test/fixtures/translations/en/default.json
+++ b/test/fixtures/translations/en/default.json
@@ -112,6 +112,17 @@
           "label": "Recorded Delivery"
         }
       }
+    },
+    "which-checkbox": {
+      "legend": "Which Checkbox",
+      "options": {
+        "value-one": {
+          "label": "First value"
+        },
+        "value-two": {
+          "label": "Second value"
+        }
+      }
     }
   },
   "pages": {


### PR DESCRIPTION
Changed the getValue method in helpers so that when value is a checkbox-group, it gets the labels of the checkbox options and displays that instead of the value.

It also now lists the different checkbox values by joining it with a \n.

Also added a editorconfig