### PR TITLE
Don't pass form data to email

### DIFF
--- a/lib/confirm-controller.js
+++ b/lib/confirm-controller.js
@@ -99,14 +99,17 @@ module.exports = class ConfirmController extends BaseController {
    * @returns {Object} the email config object
    */
   getEmailerConfig(req) {
-    const config = Object.assign({}, this.options.emailConfig, {
-      data: this.formattedData,
+    const includeInEmail = this.options.includeInEmail ? this.options.includeInEmail : true;
+    const options = {
       subject: helpers.conditionalTranslate(req.rawTranslate, 'pages.email.subject'),
+      includeInEmail,
       customerIntro: helpers.conditionalTranslate(req.translate, 'pages.email.intro.customer'),
       caseworkerIntro: helpers.conditionalTranslate(req.translate, 'pages.email.intro.caseworker'),
       customerOutro: helpers.conditionalTranslate(req.translate, 'pages.email.outro.customer'),
       caseworkerOutro: helpers.conditionalTranslate(req.translate, 'pages.email.outro.caseworker')
-    });
+    };
+    options.data = includeInEmail ? this.formattedData : false;
+    const config = Object.assign({}, this.options.emailConfig, options);
     if (this.options.emailUser !== false) {
       config.customerEmail = req.sessionModel.get(this.options.customerEmailField);
     }

--- a/lib/confirm-controller.js
+++ b/lib/confirm-controller.js
@@ -99,7 +99,7 @@ module.exports = class ConfirmController extends BaseController {
    * @returns {Object} the email config object
    */
   getEmailerConfig(req) {
-    const includeInEmail = this.options.includeInEmail ? this.options.includeInEmail : true;
+    const includeInEmail = this.options.includeInEmail !== undefined ? this.options.includeInEmail : true;
     const options = {
       subject: helpers.conditionalTranslate(req.rawTranslate, 'pages.email.subject'),
       includeInEmail,

--- a/test/lib/confirm-controller.js
+++ b/test/lib/confirm-controller.js
@@ -336,6 +336,7 @@ describe('Confirm Controller', () => {
         it('extends the config from step with translated values', () => {
           confirmController.getEmailerConfig(req).should.be.deep.equal({
             port: '',
+            includeInEmail: true,
             data: {
               a: 'value'
             },


### PR DESCRIPTION
Changed getEmailerConfig in confirm-controller so that if includeInEmail option is false, then data is not passed to the Email service. If it does not exist then its set to true. This is for the projects that already use this.
