### PR TITLE
bugfix - fix for mutating array in sessionModel

### DIFF
--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -84,15 +84,11 @@ module.exports = class Helpers {
     if (!Array.isArray(values)) {
       values = [values];
     }
-    values.forEach((value, index) => {
+    return values.map(value => {
       let key = `fields.${field}.options.${value}.label`;
       let result = translate(key);
-      if (result === key) {
-        result = value;
-      }
-      values[index] = result;
-    });
-    return values.join('\n');
+      return result === key ? value : result;
+    }).join('\n');
   }
 
   /**


### PR DESCRIPTION
when calling the getValue helper we were mutating the original array. This was somehow being stored in the sessionModel - it seems that the stored value in the sessionModel is just a reference to an array so when amending values directly (after calling .toJSON()) the mutated results were being persisted

* replaced forEach with a .map to prevent altering the original values