### PR TITLE
bugfix - skip date validation when dependent condition not met

### DIFF
--- a/lib/date-controller.js
+++ b/lib/date-controller.js
@@ -51,17 +51,24 @@ module.exports = class DateController extends BaseController {
   validateDateField(req, key) {
     const value = req.form.values[this.dateKey];
     const validatorTypes = this.getValidatorTypes(key);
+    const field = this.options.fields[key];
+    if (field.dependent && req.form.values[field.dependent.field] !== field.dependent.value) {
+      return;
+    }
+
     const type = _.result(_.find(validators, validator => {
       if (validatorTypes.indexOf(validator.type) !== -1) {
         return validator.method(value);
       }
     }), 'type');
     if (type) {
+      /* eslint-disable consistent-return */
       return new ErrorController(this.dateKey, {
         key: this.dateKey,
         redirect: undefined,
         type
       });
+      /* eslint-enable consistent-return */
     }
   }
 

--- a/test/lib/date-controller.js
+++ b/test/lib/date-controller.js
@@ -202,6 +202,31 @@ describe('lib/date-controller', () => {
     });
   });
 
+  describe('validateDateField', () => {
+    beforeEach(() => {
+      sinon.stub(DateController.prototype, 'getValidatorTypes').returns([]);
+    });
+
+    afterEach(() => {
+      DateController.prototype.getValidatorTypes.restore();
+    });
+
+    it('returns if the field has a dependent which is not satisfied', () => {
+      const req = {
+        form: {
+          values: {
+            'dependent-field': 'dependent-value'
+          }
+        }
+      };
+      controller.options.fields.date.dependent = {
+        field: 'dependent-field',
+        value: 'dependent-value'
+      };
+      chai.expect(controller.validateDateField(req, 'date')).to.be.undefined;
+    });
+  });
+
   describe('.process()', () => {
     describe('with all date parts', () => {
       const req = {


### PR DESCRIPTION
This functionality exists in core but was missed when this controller was written. This means that date field is always validated, even when it isn't required. Use case would be a conditional reveal with a date hidden until parent selected.