### PR TITLE
bugfix - use sessionModel for formatted data, not instance

### DIFF
--- a/lib/confirm-controller.js
+++ b/lib/confirm-controller.js
@@ -57,18 +57,6 @@ module.exports = class ConfirmController extends BaseController {
   }
 
   /**
-   * sets formattedData in the sessionModel from
-   * the result of this.formatData, calls super
-   * @param {Object} req - the HTTP request Object
-   * @param {Object} res - the HTTP response Object
-   * @param {Function} cb - the callback function
-   */
-  get(req, res, cb) {
-    req.sessionModel.set('formattedData', this.formatData(req.sessionModel.toJSON(), req.translate));
-    super.get(req, res, cb);
-  }
-
-  /**
    * extends super.locals with rows - a formatted representation
    * of the user entered data grouped by section.
    * @param {Object} req - the HTTP request object
@@ -76,8 +64,9 @@ module.exports = class ConfirmController extends BaseController {
    * @returns {Object} return value of super.locals extended with rows
    */
   locals(req, res) {
-    const rows = req.sessionModel.get('formattedData');
-    return Object.assign({}, super.locals(req, res), {rows});
+    return Object.assign({}, super.locals(req, res), {
+      rows: this.formatData(req.sessionModel.toJSON(), req.translate)
+    });
   }
 
   /**
@@ -88,7 +77,7 @@ module.exports = class ConfirmController extends BaseController {
    */
   getEmailerConfig(req) {
     const config = Object.assign({}, this.options.emailConfig, {
-      data: req.sessionModel.get('formattedData'),
+      data: this.formatData(req.sessionModel.toJSON(), req.translate),
       subject: helpers.conditionalTranslate(req.rawTranslate, 'pages.email.subject'),
       customerIntro: helpers.conditionalTranslate(req.translate, 'pages.email.intro.customer'),
       caseworkerIntro: helpers.conditionalTranslate(req.translate, 'pages.email.intro.caseworker'),

--- a/lib/confirm-controller.js
+++ b/lib/confirm-controller.js
@@ -57,38 +57,26 @@ module.exports = class ConfirmController extends BaseController {
   }
 
   /**
-   * sets formattedData on the controller instance
-   * from the result of this.formatData, calls super
+   * sets formattedData in the sessionModel from
+   * the result of this.formatData, calls super
    * @param {Object} req - the HTTP request Object
    * @param {Object} res - the HTTP response Object
    * @param {Function} cb - the callback function
    */
   get(req, res, cb) {
-    this.formattedData = this.formatData(req.sessionModel.toJSON(), req.translate);
+    req.sessionModel.set('formattedData', this.formatData(req.sessionModel.toJSON(), req.translate));
     super.get(req, res, cb);
   }
 
   /**
-   * sets formattedData on the controller instance
-   * from the result of this.formatData, calls super
-   * @param {Object} req - the HTTP request Object
-   * @param {Object} res - the HTTP response Object
-   * @param {Function} cb - the callback function
-   */
-  post(req, res, cb) {
-    this.formattedData = this.formatData(req.sessionModel.toJSON(), req.translate);
-    super.post(req, res, cb);
-  }
-
-  /**
-   * extends super.locals with tableSections - a formatted representation
+   * extends super.locals with rows - a formatted representation
    * of the user entered data grouped by section.
    * @param {Object} req - the HTTP request object
    * @param {Object} res - the HTTP response object
-   * @returns {Object} return value of super.locals extended with tableSections
+   * @returns {Object} return value of super.locals extended with rows
    */
   locals(req, res) {
-    const rows = this.formattedData;
+    const rows = req.sessionModel.get('formattedData');
     return Object.assign({}, super.locals(req, res), {rows});
   }
 
@@ -100,7 +88,7 @@ module.exports = class ConfirmController extends BaseController {
    */
   getEmailerConfig(req) {
     const config = Object.assign({}, this.options.emailConfig, {
-      data: this.formattedData,
+      data: req.sessionModel.get('formattedData'),
       subject: helpers.conditionalTranslate(req.rawTranslate, 'pages.email.subject'),
       customerIntro: helpers.conditionalTranslate(req.translate, 'pages.email.intro.customer'),
       caseworkerIntro: helpers.conditionalTranslate(req.translate, 'pages.email.intro.caseworker'),

--- a/test/lib/confirm-controller.js
+++ b/test/lib/confirm-controller.js
@@ -110,10 +110,6 @@ describe('Confirm Controller', () => {
       ConfirmController.prototype.should.haveOwnProperty('formatData');
     });
 
-    it('has a get method', () => {
-      ConfirmController.prototype.should.haveOwnProperty('get');
-    });
-
     it('has a locals method', () => {
       ConfirmController.prototype.should.haveOwnProperty('locals');
     });
@@ -145,7 +141,7 @@ describe('Confirm Controller', () => {
 
       beforeEach(() => {
         req.sessionModel.get = sinon.stub();
-        req.sessionModel.set = sinon.stub();
+        req.sessionModel.toJSON = sinon.stub();
       });
 
       describe('formatData', () => {
@@ -262,14 +258,8 @@ describe('Confirm Controller', () => {
         });
       });
 
-      describe('get', () => {
-        const data = {
-          a: 'value'
-        };
-
+      describe('locals', () => {
         beforeEach(() => {
-          req.sessionModel.toJSON = sinon.stub().returns(data);
-          req.translate = {};
           sinon.stub(ConfirmController.prototype, 'formatData');
         });
 
@@ -277,28 +267,6 @@ describe('Confirm Controller', () => {
           ConfirmController.prototype.formatData.restore();
         });
 
-        it('saves the return value of formatData to the sessionModel', () => {
-          const result = {a: 'value'};
-          ConfirmController.prototype.formatData.returns(result);
-          confirmController.get(req, res, cb);
-          req.sessionModel.set.should.have.been.calledOnce
-            .and.calledWithExactly('formattedData', result);
-        });
-
-        it('calls formatData with the data and translate function', () => {
-          confirmController.get(req, res, cb);
-          ConfirmController.prototype.formatData.should.have.been.calledOnce
-            .and.calledWithExactly(data, req.translate);
-        });
-
-        it('calls super', () => {
-          confirmController.get(req, res, cb);
-          StubController.prototype.get.should.have.been.calledOnce
-            .and.calledWithExactly(req, res, cb);
-        });
-      });
-
-      describe('locals', () => {
         it('calls super', () => {
           confirmController.locals(req, res);
           StubController.prototype.locals.should.have.been.calledOnce
@@ -306,7 +274,7 @@ describe('Confirm Controller', () => {
         });
 
         it('extends super.locals with rows', () => {
-          req.sessionModel.get.withArgs('formattedData').returns([{a: 'value'}, {b: 'another value'}]);
+          ConfirmController.prototype.formatData.returns([{a: 'value'}, {b: 'another value'}]);
           StubController.prototype.locals.returns({root: 'value'});
           confirmController.locals(req, res).should.be.deep.equal({
             root: 'value',
@@ -328,7 +296,7 @@ describe('Confirm Controller', () => {
               port: ''
             }
           };
-          req.sessionModel.get.withArgs('formattedData').returns({
+          sinon.stub(ConfirmController.prototype, 'formatData').returns({
             a: 'value'
           });
           helpersStub.conditionalTranslate
@@ -337,6 +305,10 @@ describe('Confirm Controller', () => {
             .onCall(2).returns('caseworker-intro')
             .onCall(3).returns('customer-outro')
             .onCall(4).returns('caseworker-outro');
+        });
+
+        afterEach(() => {
+          ConfirmController.prototype.formatData.restore();
         });
 
         it('extends the config from step with translated values', () => {

--- a/test/lib/confirm-controller.js
+++ b/test/lib/confirm-controller.js
@@ -137,9 +137,17 @@ describe('Confirm Controller', () => {
     });
 
     describe('public methods', () => {
-      let req = {};
+      let req = {
+        sessionModel: {}
+      };
       let res = {};
       let cb;
+
+      beforeEach(() => {
+        req.sessionModel.get = sinon.stub();
+        req.sessionModel.set = sinon.stub();
+      });
+
       describe('formatData', () => {
         let result;
         let translate;
@@ -260,9 +268,7 @@ describe('Confirm Controller', () => {
         };
 
         beforeEach(() => {
-          req.sessionModel = {
-            toJSON: sinon.stub().returns(data)
-          };
+          req.sessionModel.toJSON = sinon.stub().returns(data);
           req.translate = {};
           sinon.stub(ConfirmController.prototype, 'formatData');
         });
@@ -271,12 +277,12 @@ describe('Confirm Controller', () => {
           ConfirmController.prototype.formatData.restore();
         });
 
-        it('saves the return value of formatData to the instance', () => {
+        it('saves the return value of formatData to the sessionModel', () => {
           const result = {a: 'value'};
           ConfirmController.prototype.formatData.returns(result);
           confirmController.get(req, res, cb);
-          confirmController.formattedData.should.be.ok
-            .and.be.equal(result);
+          req.sessionModel.set.should.have.been.calledOnce
+            .and.calledWithExactly('formattedData', result);
         });
 
         it('calls formatData with the data and translate function', () => {
@@ -300,7 +306,7 @@ describe('Confirm Controller', () => {
         });
 
         it('extends super.locals with rows', () => {
-          confirmController.formattedData = [{a: 'value'}, {b: 'another value'}];
+          req.sessionModel.get.withArgs('formattedData').returns([{a: 'value'}, {b: 'another value'}]);
           StubController.prototype.locals.returns({root: 'value'});
           confirmController.locals(req, res).should.be.deep.equal({
             root: 'value',
@@ -322,9 +328,9 @@ describe('Confirm Controller', () => {
               port: ''
             }
           };
-          confirmController.formattedData = {
+          req.sessionModel.get.withArgs('formattedData').returns({
             a: 'value'
-          };
+          });
           helpersStub.conditionalTranslate
             .onCall(0).returns('subject')
             .onCall(1).returns('customer-intro')


### PR DESCRIPTION
ConfirmController was using the instance for storing formattedData for use in confirm page and email templates. This change performs the logic only on GET requests and stores the result in the sessionModel for use in templates and later POST requests

* amended get method to save formattedData to sessionModel rather than instance
* removed post method
* amended locals method to take formattedData from the sessionModel rather than instance
* amended getEmailerConfig method to take formattedData from the sessionMosdel rather than instance