### PR TITLE
Feature - enable hof-components

### DIFF
--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -12,6 +12,15 @@ module.exports = class BaseController extends Controller {
     super(options);
     this.confirmStep = options.confirmStep || '/confirm';
     this.use(lambdas());
+    this.applyComponents();
+  }
+
+  applyComponents() {
+    _(this.options.fields)
+      .pickBy(field => field.component && typeof field.component === 'function')
+      .each((field, key) => {
+        this.use(field.component(Object.assign({}, field, {key})).requestHandler());
+      });
   }
 
   get(req, res, callback) {
@@ -83,6 +92,13 @@ module.exports = class BaseController extends Controller {
     return redirect;
   }
 
+  getErrors(req, res) {
+    let errs = super.getErrors(req, res);
+    var componentErrors = req.sessionModel.get('componentErrors');
+    errs = Object.assign({}, errs, componentErrors);
+    return errs;
+  }
+
   locals(req, res) {
     const lookup = i18nLookup(req.translate, Mustache.render);
     const route = this.options.route.replace(/^\//, '');
@@ -92,7 +108,8 @@ module.exports = class BaseController extends Controller {
     const fields = _.map(this.options.fields, (field, key) => ({
       key,
       mixin: field.mixin,
-      useWhen: field.useWhen
+      useWhen: field.useWhen,
+      html: res.locals[key]
     }));
 
     return _.extend({}, locals, {
@@ -103,7 +120,7 @@ module.exports = class BaseController extends Controller {
       intro: helpers.getIntro(route, lookup, res.locals),
       backLink: this.getBackLink(req, res),
       nextPage: this.getNextStep(req, res),
-      errorLength: this.getErrorLength(req, res),
+      errorLength: this.getErrorLength(req, res)
     }, stepLocals);
   }
 


### PR DESCRIPTION
This change will allow hof-components to be processed as middleware from controllers extending from hof base controller. PR pending for hof-component-date and another to follow in hof-template-partials.

* check fields for components on init
* loop over and init components, applying as middleware
* extended getErrors to include componentErrors set in the component
* extended fields in locals to include optional property `html` - this is used to include a pre-rendered html string if available