### PR TITLE
Move core controller code from the hof-form-wizard project into here

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 'use strict';
 
 module.exports = {
+  form: require('./lib/form-controller'),
   base: require('./lib/base-controller'),
   date: require('./lib/date-controller'),
   confirm: require('./lib/confirm-controller'),
-  error: require('./lib/error-controller'),
+  error: require('./lib/error'),
   start: require('./lib/start-controller')
 };

--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const i18nLookup = require('i18n-lookup');
 const Mustache = require('mustache');
 const helpers = require('./util/helpers');
-const Controller = require('hof-form-wizard').Controller;
+const Controller = require('./form-controller');
 const lambdas = require('./middleware/lambdas');
 
 module.exports = class BaseController extends Controller {
@@ -26,8 +26,11 @@ module.exports = class BaseController extends Controller {
 
   getNextStep(req, res) {
     let next = super.getNextStep(req, res);
-    const forks = this.options.forks || [];
-    const confirmStep = req.baseUrl === '/' ? this.confirmStep : req.baseUrl + this.confirmStep;
+    const forks = req.form.options.forks || [];
+
+    const normaliseUrl = url => req.baseUrl === '/' ? url : req.baseUrl + url;
+
+    const confirmStep = normaliseUrl(this.confirmStep);
 
     const completed = step => {
       if (req.baseUrl !== '/') {
@@ -47,15 +50,14 @@ module.exports = class BaseController extends Controller {
       };
 
       return evalCondition(value.condition) ?
-        req.baseUrl + value.target :
+        normaliseUrl(value.target) :
         result;
     }, next);
-
     if ((req.params.action === 'edit') && completed(next)) {
       // The user is editing the form and has already completed the next
       // step, so let's check whether we should fast-forward them to the
       // confirm page
-      next = (!this.options.continueOnEdit || next === confirmStep) ?
+      next = (!req.form.options.continueOnEdit || next === confirmStep) ?
         confirmStep :
         next + '/edit';
     }
@@ -85,11 +87,11 @@ module.exports = class BaseController extends Controller {
 
   locals(req, res) {
     const lookup = i18nLookup(req.translate, Mustache.render);
-    const route = this.options.route.replace(/^\//, '');
+    const route = req.form.options.route.replace(/^\//, '');
     const locals = super.locals(req, res);
-    const stepLocals = this.options.locals || {};
+    const stepLocals = req.form.options.locals || {};
 
-    const fields = _.map(this.options.fields, (field, key) => ({
+    const fields = _.map(req.form.options.fields, (field, key) => ({
       key,
       mixin: field.mixin,
       useWhen: field.useWhen
@@ -99,7 +101,7 @@ module.exports = class BaseController extends Controller {
       fields,
       route,
       baseUrl: req.baseUrl,
-      title: helpers.getTitle(route, lookup, this.options.fields, res.locals),
+      title: helpers.getTitle(route, lookup, req.form.options.fields, res.locals),
       intro: helpers.getIntro(route, lookup, res.locals),
       backLink: this.getBackLink(req, res),
       nextPage: this.getNextStep(req, res),
@@ -112,8 +114,8 @@ module.exports = class BaseController extends Controller {
       if (err) {
         return callback(err, values);
       }
-      const noNext = _.isUndefined(this.options.next);
-      const clearSession = this.options.clearSession;
+      const noNext = _.isUndefined(req.form.options.next);
+      const clearSession = req.form.options.clearSession;
       // clear the session if there's no next step or we request to clear the session
       if ((noNext && clearSession !== false) || clearSession === true) {
         req.sessionModel.reset();

--- a/lib/date-controller.js
+++ b/lib/date-controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const BaseController = require('./base-controller');
-const ErrorController = require('./error-controller');
+const ErrorClass = require('./error');
 const moment = require('moment');
 const _ = require('lodash');
 const dateFormat = 'DD-MM-YYYY';
@@ -63,7 +63,7 @@ module.exports = class DateController extends BaseController {
     }), 'type');
     if (type) {
       /* eslint-disable consistent-return */
-      return new ErrorController(this.dateKey, {
+      return new ErrorClass(this.dateKey, {
         key: this.dateKey,
         redirect: undefined,
         type

--- a/lib/error-controller.js
+++ b/lib/error-controller.js
@@ -1,5 +1,0 @@
-'use strict';
-
-const ErrorClass = require('hof-form-wizard').Error;
-
-module.exports = class ErrorController extends ErrorClass {};

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const _ = require('lodash');
+const i18nLookup = require('i18n-lookup');
+const BaseError = require('hof-form-controller').Error;
+
+function getArgs(type, args) {
+  if (type === 'past') {
+    return {
+      age: args.join(' ')
+    };
+  } else if (Array.isArray(args) && typeof type === 'string') {
+    var obj = {};
+    obj[type] = args[0];
+    return obj;
+  }
+  return {};
+}
+
+function compile(t, context) {
+  return require('hogan.js').compile(t).render(context);
+}
+
+module.exports = class FormError extends BaseError {
+  constructor(key, options, req, res) {
+    super(key, options, req, res);
+    req = req || {};
+    if (typeof req.translate === 'function') {
+      this.translate = req.translate;
+    }
+  }
+
+  getMessage(key, options, req, res) {
+    res = res || {};
+    const keys = [
+      'validation.' + key + '.' + options.type,
+      'validation.' + key + '.default',
+      'validation.' + options.type,
+      'validation.default'
+    ];
+    const context = Object.assign({
+      label: this.translate('fields.' + key + '.label').toLowerCase(),
+      legend: this.translate('fields.' + key + '.legend').toLowerCase()
+    }, res.locals, getArgs(options.type, options.arguments));
+
+    return i18nLookup(this.translate, compile)(keys, context);
+  }
+
+  translate() {
+    return _.identity.apply(_, arguments);
+  }
+};

--- a/lib/form-controller.js
+++ b/lib/form-controller.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const _ = require('lodash');
+const path = require('path');
+const ErrorClass = require('./error');
+const Form = require('hof-form-controller');
+
+module.exports = class Controller extends Form {
+  constructor(options) {
+    super(options);
+    this.Error = ErrorClass;
+  }
+
+  getValues(req, res, callback) {
+    const json = req.sessionModel.toJSON();
+    delete json.errorValues;
+    callback(null, Object.assign({}, json, req.sessionModel.get('errorValues')));
+  }
+
+  saveValues(req, res, callback) {
+    req.sessionModel.set(req.form.values);
+    req.sessionModel.unset('errorValues');
+    callback();
+  }
+
+  getErrors(req) {
+    let errs = req.sessionModel.get('errors');
+    errs = _.pick(errs, Object.keys(this.options.fields));
+    errs = _.pickBy(errs, err => !err.redirect);
+    return errs;
+  }
+
+  setErrors(err, req) {
+    if (req.form) {
+      req.sessionModel.set('errorValues', req.form.values);
+    }
+    req.sessionModel.set('errors', err);
+  }
+
+  locals(req, res) {
+    return {
+      baseUrl: req.baseUrl,
+      nextPage: this.getNextStep(req, res)
+    };
+  }
+
+  missingPrereqHandler(req, res) {
+    const last = _.last(req.sessionModel.get('steps'));
+    let redirect = _.first(Object.keys(this.options.steps));
+
+    if (last && this.options.steps[last]) {
+      redirect = this.options.steps[last].next || last;
+    }
+    res.redirect(path.join(req.baseUrl, redirect));
+  }
+
+  errorHandler(err, req, res, next) {
+    if (err.code === 'MISSING_PREREQ') {
+      this.missingPrereqHandler(req, res, next);
+    } else {
+      super.errorHandler(err, req, res, next);
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "style": "jscs **/*.js --config=./.jscsrc.json"
   },
   "dependencies": {
-    "hof-form-wizard": "^1.0.2",
     "hof-emailer": "^1.0.0",
+    "hof-form-controller": "^2.0.0",
     "i18n-lookup": "^0.1.0",
     "lodash": "4.16.3",
     "moment": "2.15.1",
@@ -31,6 +31,7 @@
     "eslint-plugin-filenames": "^0.1.1",
     "eslint-plugin-mocha": "^0.2.2",
     "eslint-plugin-one-variable-per-var": "0.0.3",
+    "hof-model": "^2.0.0",
     "i18n-future": "^1.0.0",
     "jscs": "^1.13.1",
     "mocha": "^2.2.5",
@@ -38,6 +39,7 @@
     "mocha-multi": "^0.7.1",
     "pre-commit": "^1.0.10",
     "proxyquire": "^1.5.0",
+    "reqres": "^1.2.2",
     "sinomocha": "^0.2.4",
     "sinon": "^1.15.3",
     "sinon-chai": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "hof-emailer": "^1.0.0",
     "hof-form-controller": "^2.0.0",
+    "hogan.js": "^3.0.2",
     "i18n-lookup": "^0.1.0",
     "lodash": "4.16.3",
     "moment": "2.15.1",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -4,3 +4,7 @@ extends:
 
 env:
   es6: true
+
+rules:
+  no-underscore-dangle: 0
+  space-in-brackets: 0

--- a/test/lib/date-controller.js
+++ b/test/lib/date-controller.js
@@ -11,7 +11,7 @@ const DateController = proxyquire('../../lib/date-controller', {
   './base-controller': Controller
 });
 
-const ErrorClass = require('../../lib/error-controller');
+const ErrorClass = require('../../lib/error');
 
 describe('lib/date-controller', () => {
 

--- a/test/lib/error.js
+++ b/test/lib/error.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const ErrorClass = require('../../lib/error');
+
+const request = require('reqres').req;
+const response = require('reqres').res;
+
+describe('Error', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = request({
+      translate: sinon.stub().returnsArg(0)
+    });
+    res = response();
+  });
+
+  describe('getMessage', () => {
+    it('uses the translate method from the initialising request to translate the message', () => {
+      req.translate.withArgs('validation.key.required').returns('This field is required');
+      const error = new ErrorClass('key', { type: 'required' }, req);
+      error.message.should.equal('This field is required');
+    });
+
+    it('uses default error message for field if no field and type specific message is defined', () => {
+      req.translate.withArgs('validation.key.default').returns('Default field message');
+      const error = new ErrorClass('key', { type: 'required' }, req);
+      error.message.should.equal('Default field message');
+    });
+
+    it('uses default error message for validation type if no field level message is defined', () => {
+      req.translate.withArgs('validation.required').returns('Default required message');
+      const error = new ErrorClass('key', { type: 'required' }, req);
+      error.message.should.equal('Default required message');
+    });
+
+    it('uses global default error message if no type of field level messages are defined', () => {
+      req.translate.withArgs('validation.default').returns('Global default');
+      const error = new ErrorClass('key', { type: 'required' }, req);
+      error.message.should.equal('Global default');
+    });
+
+    it('populates messages with field label', () => {
+      req.translate.withArgs('validation.key.required').returns('Your {{label}} is required');
+      req.translate.withArgs('fields.key.label').returns('Field label');
+      const error = new ErrorClass('key', { type: 'required' }, req);
+      error.message.should.equal('Your field label is required');
+    });
+
+    it('populates messages with legend', () => {
+      req.translate.withArgs('validation.key.required').returns('Your {{legend}} is required');
+      req.translate.withArgs('fields.key.legend').returns('date');
+      const error = new ErrorClass('key', { type: 'required' }, req);
+      error.message.should.equal('Your date is required');
+    });
+
+    it('populates maxlength messages with the maximum length', () => {
+      req.translate.withArgs('validation.key.maxlength').returns('This must be less than {{maxlength}} characters');
+      const error = new ErrorClass('key', { type: 'maxlength', arguments: [10] }, req);
+      error.message.should.equal('This must be less than 10 characters');
+    });
+
+    it('populates minlength messages with the minimum length', () => {
+      req.translate.withArgs('validation.key.minlength').returns('This must be no more than {{minlength}} characters');
+      const error = new ErrorClass('key', { type: 'minlength', arguments: [10] }, req);
+      error.message.should.equal('This must be no more than 10 characters');
+    });
+
+    it('populates exactlength messages with the required length', () => {
+      req.translate.withArgs('validation.key.exactlength').returns('This must be {{exactlength}} characters');
+      const error = new ErrorClass('key', { type: 'exactlength', arguments: [10] }, req);
+      error.message.should.equal('This must be 10 characters');
+    });
+
+    it('populates past messages with the required difference', () => {
+      req.translate.withArgs('validation.key.past').returns('This must be less than {{age}} ago');
+      const error = new ErrorClass('key', { type: 'past', arguments: [5, 'days'] }, req);
+      error.message.should.equal('This must be less than 5 days ago');
+    });
+
+    it('populates custom messages with the required constiable', () => {
+      req.translate.withArgs('validation.key.custom').returns('This must be {{custom}}');
+      const error = new ErrorClass('key', { type: 'custom', arguments: ['dynamic'] }, req);
+      error.message.should.equal('This must be dynamic');
+    });
+
+    it('populates messages with values from `res.locals` when present', () => {
+      req.translate.withArgs('validation.key.required').returns('This must be a {{something}}');
+      res.locals.something = 'value';
+      const error = new ErrorClass('key', { type: 'required' }, req, res);
+      error.message.should.equal('This must be a value');
+    });
+
+    it('uses own translate method if no req.translate is defined', () => {
+      delete req.translate;
+      sinon.stub(ErrorClass.prototype, 'translate').returns('Custom translate');
+      const error = new ErrorClass('key', { type: 'required' }, req);
+      error.message.should.equal('Custom translate');
+      ErrorClass.prototype.translate.restore();
+    });
+  });
+});

--- a/test/lib/form-controller.js
+++ b/test/lib/form-controller.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const Controller = require('../../lib/form-controller');
+const ErrorClass = require('../../lib/error');
+const Form = require('hof-form-controller');
+const Model = require('hof-model');
+const request = require('reqres').req;
+const response = require('reqres').res;
+
+describe('Form Controller', () => {
+  let controller;
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    req = request({
+        sessionModel: new Model()
+    });
+    res = response();
+    next = sinon.stub();
+    controller = new Controller({
+      template: 'index',
+      fields: {
+        field1: {},
+        field2: {}
+      }
+    });
+  });
+
+  describe('validators', () => {
+    it('exposes validators', () => {
+      Controller.validators.should.eql(Form.validators);
+    });
+  });
+
+  describe('formatters', () => {
+    it('exposes formatters', () => {
+      Controller.formatters.should.eql(Form.formatters);
+    });
+  });
+
+  describe('Error', () => {
+    it('is an instance of Wizard.Error', () => {
+      const err = new controller.Error('key', { type: 'required' });
+      err.should.be.an.instanceOf(ErrorClass);
+    });
+  });
+
+  describe('getErrors', () => {
+    it('only returns errors from fields relevant to the current step', () => {
+      req.sessionModel.set('errors', {
+        field1: 'foo',
+        field3: 'bar'
+      });
+      const errors = controller.getErrors(req, res);
+      errors.should.eql({ field1: 'foo' });
+    });
+
+    it('does not return errors with a redirect property', () => {
+      req.sessionModel.set('errors', {
+        field1: {
+          redirect: '/exit-page'
+        },
+        field2: {
+          message: 'message'
+        }
+      });
+      const errors = controller.getErrors(req, res);
+      errors.should.eql({ field2: { message: 'message' } });
+    });
+  });
+
+  describe('errorHandler', () => {
+    beforeEach(() => {
+      sinon.stub(Form.prototype, 'errorHandler');
+      sinon.stub(Controller.prototype, 'missingPrereqHandler');
+    });
+
+    afterEach(() => {
+      Form.prototype.errorHandler.restore();
+      Controller.prototype.missingPrereqHandler.restore();
+    });
+
+    it('calls missingPrereqHandler for missing prerquisite errors', () => {
+      const err = new Error('foo');
+      err.code = 'MISSING_PREREQ';
+      controller.errorHandler(err, req, res, next);
+      controller.missingPrereqHandler.should.have.been.calledWithExactly(req, res, next);
+    });
+
+    it('passes through to parent errorHandler for all other errors', () => {
+      const err = new Error('foo');
+      controller.errorHandler(err, req, res, next);
+      Form.prototype.errorHandler.should.have.been.calledWithExactly(err, req, res, next);
+      Form.prototype.errorHandler.should.have.been.calledOn(controller);
+    });
+  });
+
+  describe('missingPrereqHandler', () => {
+    beforeEach(() => {
+      controller.options.steps = {
+        '/one': { next: '/two' },
+        '/two': { next: '/three' },
+        '/three': { next: '/four' },
+        '/four': {}
+      };
+    });
+
+    it('redirects to the step following the most recently completed', () => {
+      req.sessionModel.set('steps', ['/one']);
+      controller.missingPrereqHandler(req, res, next);
+      res.redirect.should.have.been.calledWith('/two');
+    });
+
+    it('redirects to the first step if no steps have been completed', () => {
+      req.sessionModel.set('steps', []);
+      controller.missingPrereqHandler(req, res, next);
+      res.redirect.should.have.been.calledWith('/one');
+    });
+  });
+});


### PR DESCRIPTION
This simplifies the dependency tree as it means all controllers are in one place, so upstream project which wish to extend controllers do not need to include the entire form wizard module.

Updates the base controller to use the dynamic config options introduced in `hof-form-controller@2.0.0`.