### PR TITLE
Bugfix - fix date validation

### DIFF
--- a/lib/date-controller.js
+++ b/lib/date-controller.js
@@ -88,24 +88,12 @@ module.exports = class DateController extends BaseController {
     }
   }
 
-  validateField(key, req, isRequired) {
-    if (typeof isRequired !== 'boolean') {
-      isRequired = true;
-    }
-
-    if (isRequired === true && this.isDateKey(key)) {
+  validateField(key, req) {
+    if (this.isDateKey(key)) {
       return this.validateDateField(req, key);
     }
 
-    if (isRequired === false && this.doValidate(req, key)) {
-      return this.validateDateField(req, key);
-    }
-
-    if (isRequired === false && this.isDateKey(key)) {
-      return undefined;
-    }
-
-    return super.validateField(key, req, isRequired);
+    return super.validateField(key, req);
   }
 
   saveValues(req, res, callback) {

--- a/test/lib/date-controller.js
+++ b/test/lib/date-controller.js
@@ -128,27 +128,11 @@ describe('lib/date-controller', () => {
 
     describe('when the date is not required', () => {
 
-      describe('required error', () => {
-
-        it('does not return an error when the field is undefined', () => {
-          req.form.values.date = undefined;
-
-          should.equal(controller.validateField('date', req, false), undefined);
-        });
-
-        it('does not return an error when the field is an empty string', () => {
-          req.form.values.date = '';
-
-          should.equal(controller.validateField('date', req, false), undefined);
-        });
-
-      });
-
       describe('numeric error', () => {
 
         it('returns an error class when the field is not numeric', () => {
           req.form.values.date = 'ab-cd-efgh';
-          const numericCheck = controller.validateField('date', req, false);
+          const numericCheck = controller.validateField('date', req);
 
           numericCheck.should.be.an.instanceof(ErrorClass);
           numericCheck.should.have.property('key').and.equal('date');


### PR DESCRIPTION
Superfluous param `isRequired` was being passed to validateField, and then on to super.validate field. As this now expects an optional validator function as the third argument, this was causing an error during validation.  Removed isRequired and corresponding tests