### PR TITLE
Use dynamic field config to whitelist errors in `getErrors`

### DIFF
--- a/lib/form-controller.js
+++ b/lib/form-controller.js
@@ -25,7 +25,7 @@ module.exports = class Controller extends Form {
 
   getErrors(req) {
     let errs = req.sessionModel.get('errors');
-    errs = _.pick(errs, Object.keys(this.options.fields));
+    errs = _.pick(errs, Object.keys(req.form.options.fields));
     errs = _.pickBy(errs, err => !err.redirect);
     return errs;
   }

--- a/test/lib/form-controller.js
+++ b/test/lib/form-controller.js
@@ -13,7 +13,7 @@ describe('Form Controller', () => {
   let res;
   let next;
 
-  beforeEach(() => {
+  beforeEach((done) => {
     req = request({
         sessionModel: new Model()
     });
@@ -26,6 +26,7 @@ describe('Form Controller', () => {
         field2: {}
       }
     });
+    controller._configure(req, res, done);
   });
 
   describe('validators', () => {
@@ -68,6 +69,16 @@ describe('Form Controller', () => {
       });
       const errors = controller.getErrors(req, res);
       errors.should.eql({ field2: { message: 'message' } });
+    });
+
+    it('includes errors on dynamically created fields', () => {
+      req.sessionModel.set('errors', {
+        field1: 'foo',
+        field3: 'bar'
+      });
+      req.form.options.fields.field3 = {};
+      const errors = controller.getErrors(req, res);
+      errors.should.eql({ field1: 'foo', field3: 'bar' });
     });
   });
 


### PR DESCRIPTION
The new address components dynamically add fields, which need to be included in the errors filtered by `getErrors`